### PR TITLE
Remove docs dependencies from default install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,6 @@ dependencies = [
     "scikit-learn",
     "scanpy",
     "matplotlib_scalebar",
-    "myst-nb",
-    "sphinx-copybutton",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
When installing just the package spatialdata-plot, it also pulls Sphinx packages. This is a problem, because they have here rather high minimum constraints which conflict with other packages' maximum constraints.

Actually, `myst-nb` and `sphinx-copybutton` are not needed for spatialdata-plot to run, and are already included in the optional docs dependencies. So it is save to remove them.