### PR TITLE
Avoid dropping rendering commands

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -567,7 +567,7 @@ class PlotAccessor:
         ]
 
         # prepare rendering params
-        render_cmds = OrderedDict()
+        render_cmds = []
         for cmd, params in plotting_tree.items():
             # strip prefix from cmd and verify it's valid
             cmd = "_".join(cmd.split("_")[1:])
@@ -577,9 +577,9 @@ class PlotAccessor:
 
             if "render" in cmd:
                 # verify that rendering commands have been called before
-                render_cmds[cmd] = params
+                render_cmds.append((cmd, params))
 
-        if len(render_cmds.keys()) == 0:
+        if len(render_cmds) == 0:
             raise TypeError("Please specify what to plot using the 'render_*' functions before calling 'imshow()'.")
 
         if title is not None:
@@ -609,7 +609,7 @@ class PlotAccessor:
         # Check if user specified only certain elements to be plotted
         cs_contents = _get_cs_contents(sdata)
         elements_to_be_rendered = []
-        for cmd, params in render_cmds.items():
+        for cmd, params in render_cmds:
             if cmd == "render_images" and cs_contents.query(f"cs == '{cs}'")["has_images"][0]:  # noqa: SIM114
                 if params.elements is not None:
                     elements_to_be_rendered += (
@@ -632,13 +632,14 @@ class PlotAccessor:
                     )
 
         # filter out cs without relevant elements
+        cmds = [cmd for cmd, _ in render_cmds]
         coordinate_systems = _get_valid_cs(
             sdata=sdata,
             coordinate_systems=coordinate_systems,
-            render_images="render_images" in render_cmds,
-            render_labels="render_labels" in render_cmds,
-            render_points="render_points" in render_cmds,
-            render_shapes="render_shapes" in render_cmds,
+            render_images="render_images" in cmds,
+            render_labels="render_labels" in cmds,
+            render_points="render_points" in cmds,
+            render_shapes="render_shapes" in cmds,
             elements=elements_to_be_rendered,
         )
 
@@ -689,7 +690,7 @@ class PlotAccessor:
             wants_shapes = False
             wanted_elements = []
 
-            for cmd, params in render_cmds.items():
+            for cmd, params in render_cmds:
                 if cmd == "render_images" and has_images:
                     wants_images = True
                     wanted_images = params.elements if params.elements is not None else list(sdata.images.keys())


### PR DESCRIPTION
When issueing multiple render commands of the same type, only the last command is executed. Multiple same rendering commands can be desired when blending different images (with alpha != 1) or creating a collage of images at different spatial locations.

This is caused by storing parameters in an ordered dictionary with the command type as key. Instead, onecould directly use a sequence of tuples.