### PR TITLE
`get_elements` fails on empty SpatialData 

### DIFF
--- a/src/spatialdata_plot/pp/basic.py
+++ b/src/spatialdata_plot/pp/basic.py
@@ -135,14 +135,15 @@ class PreprocessingAccessor:
         valid_shape_keys = list(self._sdata.shapes.keys()) if hasattr(self._sdata, "shapes") else None
         valid_point_keys = list(self._sdata.points.keys()) if hasattr(self._sdata, "points") else None
 
-        # first, extract coordinate system keys becasuse they generate implicit keys
-        mapping = _get_coordinate_system_mapping(self._sdata)
+        # first, extract coordinate system keys because they generate implicit keys
         implicit_keys = []
-        for e in elements:
-            for valid_coord_key in valid_coord_keys:
-                if (valid_coord_keys is not None) and (e == valid_coord_key):
-                    coord_keys.append(e)
-                    implicit_keys += mapping[e]
+        if elements:
+            mapping = _get_coordinate_system_mapping(self._sdata)
+            for e in elements:
+                for valid_coord_key in valid_coord_keys:
+                    if (valid_coord_keys is not None) and (e == valid_coord_key):
+                        coord_keys.append(e)
+                        implicit_keys += mapping[e]
 
         for e in elements + implicit_keys:
             found = False

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -24,7 +24,7 @@ def test_can_subset_to_one_or_more_images(sdata, keys, request):
     [
         ("empty", []),
     ],
-    indirect=["sdata"]
+    indirect=["sdata"],
 )
 def test_can_subset_empty_sdata(sdata, keys):
     """Tests whether a subset of images can be selected from the sdata object."""

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -20,6 +20,20 @@ def test_can_subset_to_one_or_more_images(sdata, keys, request):
 
 
 @pytest.mark.parametrize(
+    "sdata, keys",
+    [
+        ("empty", []),
+    ],
+    indirect=["sdata"]
+)
+def test_can_subset_empty_sdata(sdata, keys):
+    """Tests whether a subset of images can be selected from the sdata object."""
+    clipped_sdata = sdata.pp.get_elements(keys)
+
+    assert list(clipped_sdata.images.keys()) == ([keys] if isinstance(keys, str) else keys)
+
+
+@pytest.mark.parametrize(
     "sdata",
     [
         "test_sdata_single_image",


### PR DESCRIPTION
When SpatialData has no elements and I select no elements from it, I expected it to be a valid operation. However, an error is raised:
```python
from spatialdata import SpatialData
import spatialdata_plot
SpatialData().pp.get_elements(elements=[])
# ValueError: SpatialData object must have at least one coordinate system to generate a mapping.
```

This is because the implementation tries to get coordinate system names, which are bound on the existence of elements.

While it is unlikely users will want this rare use case, when I test my own code systematically with a matrix of edge cases, this issue makes my tests fail and I have to add workarounds.