### PR TITLE
Fix "xarray has no attribute reshape"

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -663,7 +663,7 @@ def _render_labels(
         else:
             # Default: no alpha, contour = infill
             label = _map_color_seg(
-                seg=label,
+                seg=label.values,
                 cell_id=instance_id,
                 color_vector=color_vector,
                 color_source_vector=color_source_vector,


### PR DESCRIPTION
A `.values` attribute has been forgotten.

`label` is a SpatialImage and DataArray. Scikit-image expects a true array with a reshape method. All other uses of `_map_color_seg` pass the correct value, e.g.:
https://github.com/scverse/spatialdata-plot/blob/09a31adec012483d1bc578a1fa4802ce8e8b8046/src/spatialdata_plot/pl/render.py#L618-L620