### PR TITLE
Categorical Legend Fix

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -804,8 +804,8 @@ def _decorate_axs(
         # Adding legends
         if is_categorical_dtype(color_source_vector):
             # order of clusters should agree to palette order
-            clusters: pd.Categorical = color_source_vector.unique()
-            clusters: pd.Categorical = clusters[~clusters.isnull()]
+            clusters_unique: pd.Categorical = color_source_vector.unique()
+            clusters: pd.Categorical = clusters_unique[~clusters_unique.isnull()]
             palette = _get_palette(
                 adata=adata, cluster_key=value_to_plot, categories=clusters, palette=palette, alpha=alpha
             )

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -713,6 +713,7 @@ def _get_palette(
     palette: ListedColormap | str | list[str] | None = None,
     alpha: float = 1.0,
 ) -> Mapping[str, str] | None:
+    categories = categories.categories
     if adata is not None and palette is None:
         try:
             palette = adata.uns[f"{cluster_key}_colors"]  # type: ignore[arg-type]

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -707,7 +707,7 @@ def _map_color_seg(
 
 
 def _get_palette(
-    categories: Sequence[Any],
+    categories: pd.Categorical,
     adata: AnnData | None = None,
     cluster_key: None | str = None,
     palette: ListedColormap | str | list[str] | None = None,
@@ -804,8 +804,8 @@ def _decorate_axs(
         # Adding legends
         if is_categorical_dtype(color_source_vector):
             # order of clusters should agree to palette order
-            clusters = color_source_vector.unique()
-            clusters = clusters[~clusters.isnull()]
+            clusters: pd.Categorical = color_source_vector.unique()
+            clusters: pd.Categorical = clusters[~clusters.isnull()]
             palette = _get_palette(
                 adata=adata, cluster_key=value_to_plot, categories=clusters, palette=palette, alpha=alpha
             )


### PR DESCRIPTION
Closes #214.

When plotting the SpatialData labels element, the colors are incorrectly labeled in the legend of the figure when `palette` and `color` parameters are used in the `pl.render_labels` method.

This is due to `pl.utils._get_palette` using the values in the `categories` (`pd.Categorical`) DataFrame, instead of the *categories* of `categories`.

Here is point8 from the MIBITOF dataset with the corrected color-label legend mappings.
![point8_labels](https://github.com/scverse/spatialdata-plot/assets/8909315/e819b1f4-bd46-451f-8dd4-356dbd618a7b)

