### PR TITLE
Enabling tests and docs against spatialdata pre-release

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -49,7 +49,7 @@ jobs:
           pip install pytest-cov
       - name: Install dependencies
         run: |
-          pip install -e ".[dev,test]"
+          pip install --pre -e ".[dev,test]"
       - name: Test
         env:
           MPLBACKEND: agg

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,4 @@ python:
       path: .
       extra_requirements:
         - docs
+        - pre

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ test = [
     "pytest",
     "pytest-cov",
 ]
+# this will be used by readthedocs and will make pip also look for pre-releases, generally installing the latest available version
+pre = [
+    "spatialdata>=0.1.0-pre0"
+]
 
 [tool.coverage.run]
 source = ["spatialdata_plot"]


### PR DESCRIPTION
The docs in main build even if the code is using functions not available in `spatialdata-0.0.16` (but available in the latest pre-release). This could be due to the fact when building the docs only, the only .py files that are imported are not importing functions available only in the pre-release. Same for the tests, maybe the new functions are not covered by tests.

Anyway, I am merging preventively this PR.