### PR TITLE
Fix var plotting

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -677,17 +677,6 @@ def _render_labels(
                 na_color=render_params.cmap_params.na_color,
             )
 
-            _cax = ax.imshow(
-                labels_infill,
-                rasterized=True,
-                cmap=None if categorical else render_params.cmap_params.cmap,
-                norm=None if categorical else render_params.cmap_params.norm,
-                alpha=render_params.fill_alpha,
-                origin="lower",
-            )
-            _cax.set_transform(trans_data)
-            cax = ax.add_image(_cax)
-
             # Then overlay the contour
             labels_contour = _map_color_seg(
                 seg=label.values,
@@ -708,6 +697,16 @@ def _render_labels(
                 alpha=render_params.outline_alpha,
                 origin="lower",
             )
+            _cax = ax.imshow(
+                labels_infill,
+                rasterized=True,
+                cmap=None if categorical else render_params.cmap_params.cmap,
+                norm=None if categorical else render_params.cmap_params.norm,
+                alpha=render_params.fill_alpha,
+                origin="lower",
+            )
+            _cax.set_transform(trans_data)
+            cax = ax.add_image(_cax)
         else:
             # Default: no alpha, contour = infill
             label = _map_color_seg(

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -218,7 +218,7 @@ def _get_collection_shape(
                         " categories, set the column to categorical dtype."
                     ) from e
                 c = cmap(norm(c))
-        elif not c:
+        else:
             fill_c = ColorConverter().to_rgba_array(c)
     except ValueError:
         if norm is None:

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1970,7 +1970,7 @@ def _is_coercable_to_float(series: pd.Series) -> bool:
 def _return_list_str_none(parameter: list[str | None] | str | None) -> list[str | None]:
     """Force mypy to recognize list of string and None."""
     if isinstance(parameter, list) and all(isinstance(item, (str, type(None))) for item in parameter):
-        checked_parameter = parameter if isinstance(parameter, list) else [None]
+        checked_parameter = parameter
     else:
         checked_parameter = [None]
     return checked_parameter

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -839,7 +839,7 @@ def _decorate_axs(
     ax: Axes,
     cax: PatchCollection,
     fig_params: FigParams,
-    value_to_plot: str | None,  # str | None,
+    value_to_plot: str | None,
     color_source_vector: pd.Series[CategoricalDtype],
     adata: AnnData | None = None,
     palette: ListedColormap | str | list[str] | None = None,
@@ -1478,7 +1478,7 @@ def _validate_colors_element_table_mapping_points_shapes(
                         params.col_for_color.append(col_color)
                         element_table_mapping[element_name] = set()
                     else:
-                        if isinstance(mapping := element_table_mapping[element_name], set) and len(mapping.copy()) != 0:
+                        if isinstance(mapping := element_table_mapping[element_name], set) and len(mapping) != 0:
                             for table_name in mapping.copy():
                                 if (
                                     col_color not in sdata[table_name].obs.columns

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -206,7 +206,20 @@ def _get_collection_shape(
 
     try:
         # fails when numeric
-        fill_c = ColorConverter().to_rgba_array(c)
+        if len(c.shape) == 1 and c.shape[0] in [3, 4] and c.shape[0] == len(shapes) and c.dtype == float:
+            if norm is None:
+                c = cmap(c)
+            else:
+                try:
+                    norm = colors.Normalize(vmin=min(c), vmax=max(c))
+                except ValueError as e:
+                    raise ValueError(
+                        "Could not convert values in the `color` column to float, if `color` column represents"
+                        " categories, set the column to categorical dtype."
+                    ) from e
+                c = cmap(norm(c))
+        elif not c:
+            fill_c = ColorConverter().to_rgba_array(c)
     except ValueError:
         if norm is None:
             c = cmap(c)

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1478,13 +1478,13 @@ def _validate_colors_element_table_mapping_points_shapes(
                         params.col_for_color.append(col_color)
                         element_table_mapping[element_name] = set()
                     else:
-                        if isinstance(mapping := element_table_mapping[element_name], set) and len(mapping) != 0:
-                            for table_name in mapping.copy():
+                        if isinstance(table_set := element_table_mapping[element_name], set) and len(table_set) != 0:
+                            for table_name in table_set.copy():
                                 if (
                                     col_color not in sdata[table_name].obs.columns
                                     and col_color not in sdata[table_name].var_names
                                 ):
-                                    mapping.remove(table_name)
+                                    table_set.remove(table_name)
                                     params.col_for_color.append(None)
                                 else:
                                     params.col_for_color.append(col_color)

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1891,7 +1891,7 @@ def _match_length_elements_groups_palette(
         # We already checked before that length of groups and palette is the same
         if groups is not None:
             if len(groups) == 1:
-                params.groups = [groups[0] for _ in range(len(render_elements)) if isinstance(groups[0], list)]
+                groups_elements = [groups[0] for _ in range(len(render_elements)) if isinstance(groups[0], list)]
                 if palette is not None:
                     palette_elements = [palette[0] for _ in range(len(render_elements)) if isinstance(palette[0], list)]
                 else:


### PR DESCRIPTION
closes #234 
Follow up on #235 fixing the plotting color columns that are numerical. First this fixes the visibility of the colorbar when plotting labels with a color. The issue here was that due to the outline_alpha being set to 0 when outline is False and outline of the label being plotted after the labels it would overwrite the colorbar. This was fixed by first plotting outline and then the label. A potential issue here is that when both alpha and outline alpha are 1 the outline will not be visible, but currently I thought this best as there is no clear way to decouple the colorbar from the outline. The general rule here is whatever is plotted last is visible.

The other issue got reported by @LucaMarconato  in #234 . Ultimately, this was an issue when plotting `feature0` in the `models2` notebook in `spatialdata-notebooks`. The issue here was that 3 shapes are being plotted, one multipolygon and 2 polygons. This results in a `color_vector` of length 3 which is convertible to a RGB color, causing 1 color to be created for 3 shapes. This PR fixes the issue by checking whether we are dealing with a 1 dimensional color vector of length 3 or 4 and whether it then has the same length as the number of shapes.

The plot in `models2` would now look like this:
![afbeelding](https://github.com/scverse/spatialdata-plot/assets/22346363/c1ae607b-14af-4c46-b480-7054d37267e4)
