### PR TITLE
Fix fill alpha ignoring alpha from colormaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ tests/figures/
 
 # other
 _version.py
+/temp/

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -221,7 +221,7 @@ def _get_collection_shape(
             c = cmap(norm(c))
 
     fill_c = ColorConverter().to_rgba_array(c)
-    fill_c[..., -1] = render_params.fill_alpha
+    fill_c[..., -1] *= render_params.fill_alpha
 
     if render_params.outline_params.outline:
         outline_c = ColorConverter().to_rgba_array(render_params.outline_params.outline_color)


### PR DESCRIPTION
The `fill_alpha` parameter was overwriting the alpha values in an eventual colormap passed by the user. This PR fixes it.