### PR TITLE
basic shapes datashader rendering

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -160,6 +160,7 @@ class PlotAccessor:
         cmap: Colormap | str | None = None,
         norm: bool | Normalize = False,
         scale: float | int = 1.0,
+        method: str | None = None,
         **kwargs: Any,
     ) -> sd.SpatialData:
         """
@@ -204,6 +205,9 @@ class PlotAccessor:
             Colormap normalization for continuous annotations.
         scale : float | int, default 1.0
             Value to scale circles, if present.
+        method : str | None, optional
+            Whether to use 'matplotlib' and 'datashader'. When None, the method is
+            chosen based on the size of the data.
         **kwargs : Any
             Additional arguments to be passed to cmap and norm.
 
@@ -317,6 +321,12 @@ class PlotAccessor:
         if scale < 0:
             raise ValueError("Parameter 'scale' must be a positive number.")
 
+        if method is not None:
+            if not isinstance(method, str):
+                raise TypeError("Parameter 'method' must be a string.")
+            if method not in ["matplotlib", "datashader"]:
+                raise ValueError("Parameter 'method' must be either 'matplotlib' or 'datashader'.")
+
         sdata = self._copy()
         sdata = _verify_plotting_tree(sdata)
         n_steps = len(sdata.plotting_tree.keys())
@@ -343,6 +353,7 @@ class PlotAccessor:
             fill_alpha=fill_alpha,
             transfunc=kwargs.get("transfunc", None),
             zorder=n_steps,
+            method=method,
         )
 
         return sdata
@@ -358,6 +369,7 @@ class PlotAccessor:
         cmap: Colormap | str | None = None,
         norm: None | Normalize = None,
         size: float | int = 1.0,
+        method: str | None = None,
         **kwargs: Any,
     ) -> sd.SpatialData:
         """
@@ -392,6 +404,9 @@ class PlotAccessor:
             Colormap normalization for continuous annotations.
         size : float | int, default 1.0
             Size of the points
+        method : str | None, optional
+            Whether to use 'matplotlib' and 'datashader'. When None, the method is
+            chosen based on the size of the data.
         kwargs
             Additional arguments to be passed to cmap and norm.
 
@@ -479,6 +494,12 @@ class PlotAccessor:
         if size < 0:
             raise ValueError("Parameter 'size' must be a positive number.")
 
+        if method is not None:
+            if not isinstance(method, str):
+                raise TypeError("Parameter 'method' must be a string.")
+            if method not in ["matplotlib", "datashader"]:
+                raise ValueError("Parameter 'method' must be either 'matplotlib' or 'datashader'.")
+
         sdata = self._copy()
         sdata = _verify_plotting_tree(sdata)
         n_steps = len(sdata.plotting_tree.keys())
@@ -501,6 +522,7 @@ class PlotAccessor:
             transfunc=kwargs.get("transfunc", None),
             size=size,
             zorder=n_steps,
+            method=method,
         )
 
         return sdata

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -138,10 +138,8 @@ def _render_shapes(
 
         shapes = gpd.GeoDataFrame(shapes, geometry="geometry")
 
-        # Determine which method to use for rendering. Default is matplotlib for under 100 shapes and datashader for more
-        # User can also specify the method to use
+        # Determine which method to use for rendering
         method = render_params.method
-
         if method is None:
             method = "datashader" if len(shapes) > 100 else "matplotlib"
         elif method not in ["matplotlib", "datashader"]:

--- a/src/spatialdata_plot/pl/render_params.py
+++ b/src/spatialdata_plot/pl/render_params.py
@@ -81,6 +81,7 @@ class ShapesRenderParams:
     fill_alpha: float = 0.3
     scale: float = 1.0
     transfunc: Callable[[float], float] | None = None
+    method: str | None = None
     zorder: int | None = None
 
 
@@ -97,6 +98,7 @@ class PointsRenderParams:
     alpha: float = 1.0
     size: float = 1.0
     transfunc: Callable[[float], float] | None = None
+    method: str | None = None
     zorder: int | None = None
 
 


### PR DESCRIPTION
Provides basic datashader support for ShapeElements. Still needs to address other parameters (outlines an such), but proof of concept works!

Example rendering 2389 polygons from merfish dataset:

Using matplotlib (22.4s):
![image](https://github.com/scverse/spatialdata-plot/assets/3103744/0f65c7f5-e370-4f48-8b1d-36e1927f892a)

Using datashader (6.6s):
![image](https://github.com/scverse/spatialdata-plot/assets/3103744/e3e7da8f-3f7e-4901-80e0-fce1a6fb433d)