### PR TITLE
A couple of fixes to `render_labels`

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -697,6 +697,7 @@ def _render_labels(
                 alpha=render_params.outline_alpha,
                 origin="lower",
             )
+            _cax.set_transform(trans_data)
             _cax = ax.imshow(
                 labels_infill,
                 rasterized=True,
@@ -706,7 +707,6 @@ def _render_labels(
                 origin="lower",
             )
             _cax.set_transform(trans_data)
-            cax = ax.add_image(_cax)
         else:
             # Default: no alpha, contour = infill
             label = _map_color_seg(
@@ -728,7 +728,7 @@ def _render_labels(
                 alpha=render_params.fill_alpha,
                 origin="lower",
             )
-        _cax.set_transform(trans_data)
+            _cax.set_transform(trans_data)
         cax = ax.add_image(_cax)
 
         _ = _decorate_axs(

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -664,71 +664,48 @@ def _render_labels(
             table_name=cast(str, table_name),
         )
 
-        if (render_params.fill_alpha != render_params.outline_alpha) and render_params.contour_px is not None:
-            # First get the labels infill and plot them
-            labels_infill = _map_color_seg(
-                seg=label.values,
-                cell_id=instance_id,
-                color_vector=color_vector,
-                color_source_vector=color_source_vector,
-                cmap_params=render_params.cmap_params,
-                seg_erosionpx=None,
-                seg_boundaries=render_params.outline,
-                na_color=render_params.cmap_params.na_color,
-            )
+        # First get the labels infill and plot them
+        labels_infill = _map_color_seg(
+            seg=label.values,
+            cell_id=instance_id,
+            color_vector=color_vector,
+            color_source_vector=color_source_vector,
+            cmap_params=render_params.cmap_params,
+            seg_erosionpx=None,
+            seg_boundaries=render_params.outline,
+            na_color=render_params.cmap_params.na_color,
+        )
 
-            # Then overlay the contour
-            labels_contour = _map_color_seg(
-                seg=label.values,
-                cell_id=instance_id,
-                color_vector=color_vector,
-                color_source_vector=color_source_vector,
-                cmap_params=render_params.cmap_params,
-                seg_erosionpx=render_params.contour_px,
-                seg_boundaries=render_params.outline,
-                na_color=render_params.cmap_params.na_color,
-            )
+        # Then overlay the contour
+        labels_contour = _map_color_seg(
+            seg=label.values,
+            cell_id=instance_id,
+            color_vector=color_vector,
+            color_source_vector=color_source_vector,
+            cmap_params=render_params.cmap_params,
+            seg_erosionpx=render_params.contour_px,
+            seg_boundaries=render_params.outline,
+            na_color=render_params.cmap_params.na_color,
+        )
 
-            _cax = ax.imshow(
-                labels_contour,
-                rasterized=True,
-                cmap=None if categorical else render_params.cmap_params.cmap,
-                norm=None if categorical else render_params.cmap_params.norm,
-                alpha=render_params.outline_alpha,
-                origin="lower",
-            )
-            _cax.set_transform(trans_data)
-            _cax = ax.imshow(
-                labels_infill,
-                rasterized=True,
-                cmap=None if categorical else render_params.cmap_params.cmap,
-                norm=None if categorical else render_params.cmap_params.norm,
-                alpha=render_params.fill_alpha,
-                origin="lower",
-            )
-            _cax.set_transform(trans_data)
-        else:
-            # Default: no alpha, contour = infill
-            label = _map_color_seg(
-                seg=label.values,
-                cell_id=instance_id,
-                color_vector=color_vector,
-                color_source_vector=color_source_vector,
-                cmap_params=render_params.cmap_params,
-                seg_erosionpx=render_params.contour_px,
-                seg_boundaries=render_params.outline,
-                na_color=render_params.cmap_params.na_color,
-            )
-
-            _cax = ax.imshow(
-                label,
-                rasterized=True,
-                cmap=None if categorical else render_params.cmap_params.cmap,
-                norm=None if categorical else render_params.cmap_params.norm,
-                alpha=render_params.fill_alpha,
-                origin="lower",
-            )
-            _cax.set_transform(trans_data)
+        _cax = ax.imshow(
+            labels_contour,
+            rasterized=True,
+            cmap=None if categorical else render_params.cmap_params.cmap,
+            norm=None if categorical else render_params.cmap_params.norm,
+            alpha=render_params.outline_alpha,
+            origin="lower",
+        )
+        _cax.set_transform(trans_data)
+        _cax = ax.imshow(
+            labels_infill,
+            rasterized=True,
+            cmap=None if categorical else render_params.cmap_params.cmap,
+            norm=None if categorical else render_params.cmap_params.norm,
+            alpha=render_params.fill_alpha,
+            origin="lower",
+        )
+        _cax.set_transform(trans_data)
         cax = ax.add_image(_cax)
 
         _ = _decorate_axs(


### PR DESCRIPTION
Fixes #252, #240

This PR includes fixes to two semi-related issues:
- #252 is addressed in commit d73ccd3

While digging around for a fix to #252, I also did some additional testing which led to:
- #240 being addressed in commit 377e121

NOTE: I'm not totally sure about the validity of the changes in 377e121, since I can't quite tell which case the `else` code path is supposed to cover. From my experiments, it seemed like the code path of blending `labels_infill` and `labels_contour` could cover all combinations of `outline` and `alpha` I tried, but it's absolutely possible I missed something here.

As a comparison, I ran the following commands with and without these commits:

``` python
sdata.pl.render_labels(outline=True).pl.show()
sdata.pl.render_labels(outline=True, fill_alpha=1.0).pl.show()
```
(the corresponding `outline=False` plots look fine both with and without these changes)

**Without these commits, the outputs are:**
(notice the artifact in the top-left, as reported in #252)
![main-2](https://github.com/scverse/spatialdata-plot/assets/26062675/43f827d9-e370-48c9-976b-8f544cbfb74f)
(notice the lack of fill even though `alpha=1.0`, as reported in #240)
![main-4](https://github.com/scverse/spatialdata-plot/assets/26062675/09fd5c45-1e9e-4c07-a206-eadb7d8d1b35)

**With the fixes included here, the outputs are:**
![dev-2](https://github.com/scverse/spatialdata-plot/assets/26062675/10886099-393d-479e-b3cc-456213b7d3a2)
![dev-4](https://github.com/scverse/spatialdata-plot/assets/26062675/f6a7ac13-f186-47ff-a07d-bd410b4cf298)
