### PR TITLE
Image render param refactor

### DIFF
--- a/src/spatialdata_plot/_utils.py
+++ b/src/spatialdata_plot/_utils.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import Any, Callable, TypeVar
+
+RT = TypeVar("RT")
+
+
+def deprecation_alias(**aliases: str) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+    """
+    Decorate a function to warn user of use of arguments set for deprecation.
+
+    Parameters
+    ----------
+    aliases
+        Deprecation argument aliases to be mapped to the new arguments.
+
+    Returns
+    -------
+    A decorator that can be used to mark an argument for deprecation and substituting it with the new argument.
+
+    Raises
+    ------
+    TypeError
+        If the provided aliases are not of string type.
+
+    Example
+    -------
+    Assuming we have an argument 'table' set for deprecation and we want to warn the user and substitute with 'tables':
+
+    ```python
+    @deprecation_alias(table="tables")
+    def my_function(tables: AnnData | dict[str, AnnData]):
+        pass
+    ```
+    """
+
+    def deprecation_decorator(f: Callable[..., RT]) -> Callable[..., RT]:
+        @functools.wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> RT:
+            class_name = f.__qualname__
+            rename_kwargs(f.__name__, kwargs, aliases, class_name)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return deprecation_decorator
+
+
+def rename_kwargs(func_name: str, kwargs: dict[str, Any], aliases: dict[str, str], class_name: None | str) -> None:
+    """Rename function arguments set for deprecation and gives warning in case of usage of these arguments."""
+    for alias, new in aliases.items():
+        if alias in kwargs:
+            class_name = class_name + "." if class_name else ""
+            if new in kwargs:
+                raise TypeError(
+                    f"{class_name}{func_name} received both {alias} and {new} as arguments!"
+                    f" {alias} is being deprecated in spatialdata-plot version 0.3, only use {new} instead."
+                )
+            warnings.warn(
+                message=(
+                    f"`{alias}` is being deprecated as an argument to `{class_name}{func_name}` in spatialdata-plot "
+                    f"version 0.3, switch to `{new}` instead."
+                ),
+                category=DeprecationWarning,
+                stacklevel=3,
+            )
+            kwargs[new] = kwargs.pop(alias)

--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -501,7 +501,7 @@ class PlotAccessor:
                 cmap_params=cmap_params,
                 palette=param_values["palette"],
                 alpha=param_values["alpha"],
-                quantiles_for_norm=param_values["percentiles_for_norm"],
+                percentiles_for_norm=param_values["percentiles_for_norm"],
                 scale=param_values["scale"],
             )
             n_steps += 1

--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -23,6 +23,7 @@ from spatial_image import SpatialImage
 from spatialdata._core.data_extent import get_extent
 
 from spatialdata_plot._accessor import register_spatial_data_accessor
+from spatialdata_plot._utils import deprecation_alias
 from spatialdata_plot.pl.render import (
     _render_images,
     _render_labels,
@@ -50,6 +51,7 @@ from spatialdata_plot.pl.utils import (
     _prepare_params_plot,
     _set_outline,
     _update_params,
+    _validate_image_render_params,
     _validate_render_params,
     _validate_show_parameters,
     save_fig,
@@ -390,32 +392,38 @@ class PlotAccessor:
 
         return sdata
 
+    @deprecation_alias(elements="element", quantiles_for_norm="percentiles_for_norm", version="version 0.3.0")
     def render_images(
         self,
-        elements: list[str] | str | None = None,
+        element: str | None = None,
         channel: list[str] | list[int] | str | int | None = None,
-        cmap: list[Colormap] | Colormap | str | None = None,
+        cmap: list[Colormap | str] | Colormap | str | None = None,
         norm: Normalize | None = None,
         na_color: ColorLike | None = (0.0, 0.0, 0.0, 0.0),
-        palette: list[list[str | None]] | list[str | None] | str | None = None,
+        palette: list[str] | str | None = None,
         alpha: float | int = 1.0,
-        quantiles_for_norm: tuple[float | None, float | None] | None = None,
-        scale: list[str] | str | None = None,
+        percentiles_for_norm: tuple[float, float] | None = None,
+        scale: str | None = None,
         **kwargs: Any,
     ) -> sd.SpatialData:
         """
         Render image elements in SpatialData.
 
+        In case of no elements specified, "broadcasting" of parameters is applied. This means that for any particular
+        SpatialElement, we validate whether a given parameter is valid. If not valid for a particular SpatialElement the
+        specific parameter for that particular SpatialElement will be ignored. If you want to set specific parameters
+        for specific elements please chain the render functions: `pl.render_images(...).pl.render_images(...).pl.show()`
+        .
+
         Parameters
         ----------
-        elements : list[str] | str | None, optional
-            The name(s) of the image element(s) to render. If `None`, all image
-            elements in the `SpatialData` object will be used. If a string is provided,
-            it is converted into a single-element list.
-        channel : list[str] | list[int] | str | int | None, optional
+        element : str | None
+            The name of the image element to render. If `None`, all image
+            elements in the `SpatialData` object will be used.
+        channels : list[str] | list[int] | str | int | None, optional
             To select specific channels to plot. Can be a single channel name/int or a
             list of channel names/ints. If `None`, all channels will be used.
-        cmap : list[Colormap] | Colormap | str | None, optional
+        cmap : list[Colormap | str] | Colormap | str | None, optional
             Colormap or list of colormaps for continuous annotations, see :class:`matplotlib.colors.Colormap`.
             Each colormap applies to a corresponding channel.
         norm : Normalize | None, optional
@@ -423,26 +431,24 @@ class PlotAccessor:
             Applies to all channels if set.
         na_color : ColorLike | None, default (0.0, 0.0, 0.0, 0.0)
             Color to be used for NA values. Accepts color-like values (string, hex, RGB(A)).
-        palette : list[list[str | None]] | list[str | None] | str | None
+        palette : list[str] | str | None
             Palette to color images. In the case of a list of
             lists means that there is one list per element to be plotted in the list and this list contains the string
             indicating the palette to be used. If not provided as list of lists, broadcasting behaviour is
             attempted (use the same values for all elements).
         alpha : float | int, default 1.0
             Alpha value for the images. Must be a numeric between 0 and 1.
-        quantiles_for_norm : tuple[float | None, float | None] | None, optional
+        percentiles_for_norm : tuple[float, float] | None
             Optional pair of floats (pmin < pmax, 0-100) which will be used for quantile normalization.
-        scale : list[str] | str | None, optional
+        scale : str | None
             Influences the resolution of the rendering. Possibilities include:
                 1) `None` (default): The image is rasterized to fit the canvas size. For
                 multiscale images, the best scale is selected before rasterization.
-                2) A scale name: Renders the specified scale as-is (with adjustments for dpi
-                in `show()`).
+                2) A scale name: Renders the specified scale ( of a multiscale image) as-is
+                (with adjustments for dpi in `show()`).
                 3) "full": Renders the full image without rasterization. In the case of
                 multiscale images, the highest resolution scale is selected. Note that
                 this may result in long computing times for large images.
-                4) A list matching the list of elements. Can contain `None`, scale names, or
-                "full". Each scale applies to the corresponding element.
         kwargs
             Additional arguments to be passed to cmap, norm, and other rendering functions.
 
@@ -451,10 +457,9 @@ class PlotAccessor:
         sd.SpatialData
             The SpatialData object with the rendered images.
         """
-        params_dict = _validate_render_params(
-            "images",
+        params_dict = _validate_image_render_params(
             self._sdata,
-            elements=elements,
+            element=element,
             channel=channel,
             alpha=alpha,
             palette=palette,
@@ -462,8 +467,9 @@ class PlotAccessor:
             cmap=cmap,
             norm=norm,
             scale=scale,
-            quantiles_for_norm=quantiles_for_norm,
+            percentiles_for_norm=percentiles_for_norm,
         )
+
         sdata = self._copy()
         sdata = _verify_plotting_tree(sdata)
         n_steps = len(sdata.plotting_tree.keys())
@@ -488,15 +494,17 @@ class PlotAccessor:
                 **kwargs,
             )
 
-        sdata.plotting_tree[f"{n_steps+1}_render_images"] = ImageRenderParams(
-            elements=params_dict["elements"],
-            channel=channel,
-            cmap_params=cmap_params,
-            palette=params_dict["palette"],
-            alpha=alpha,
-            quantiles_for_norm=params_dict["quantiles_for_norm"],
-            scale=params_dict["scale"],
-        )
+        for element, param_values in params_dict.items():
+            sdata.plotting_tree[f"{n_steps+1}_render_images"] = ImageRenderParams(
+                element=element,
+                channel=param_values["channel"],
+                cmap_params=cmap_params,
+                palette=param_values["palette"],
+                alpha=param_values["alpha"],
+                quantiles_for_norm=param_values["percentiles_for_norm"],
+                scale=param_values["scale"],
+            )
+            n_steps += 1
 
         return sdata
 

--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -431,7 +431,7 @@ class PlotAccessor:
             Applies to all channels if set.
         na_color : ColorLike | None, default (0.0, 0.0, 0.0, 0.0)
             Color to be used for NA values. Accepts color-like values (string, hex, RGB(A)).
-        palette : list[str] | str | None
+        palette : list[str] | None
             Palette to color images. In the case of a list of
             lists means that there is one list per element to be plotted in the list and this list contains the string
             indicating the palette to be used. If not provided as list of lists, broadcasting behaviour is

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -34,6 +34,7 @@ from spatialdata_plot.pl.render_params import (
     ShapesRenderParams,
 )
 from spatialdata_plot.pl.utils import (
+    ax_show_and_transform,
     _decorate_axs,
     _get_collection_shape,
     _get_colors_for_categorical_obs,
@@ -450,11 +451,7 @@ def _render_images(
         cmap._init()
         cmap._lut[:, -1] = render_params.alpha
 
-        im = ax.imshow(
-            layer,
-            cmap=cmap,
-        )
-        im.set_transform(trans_data)
+        ax_show_and_transform(layer,trans_data, ax, cmap=cmap)
 
     # 2) Image has any number of channels but 1
     else:
@@ -470,12 +467,10 @@ def _render_images(
                     clip=True,
                 )
 
-            if not isinstance(render_params.cmap_params, list):
-                if render_params.cmap_params.norm:
-                    layers[c] = render_params.cmap_params.norm(layers[c])
-            else:
-                if render_params.cmap_params[ch_index].norm:
-                    layers[c] = render_params.cmap_params[ch_index].norm(layers[c])
+            if not isinstance(render_params.cmap_params, list) and render_params.cmap_params.norm:
+                layers[c] = render_params.cmap_params.norm(layers[c])
+            elif render_params.cmap_params[ch_index].norm:
+                layers[c] = render_params.cmap_params[ch_index].norm(layers[c])
 
         # 2A) Image has 3 channels, no palette info, and no/only one cmap was given
         if palette is None and n_channels == 3 and not isinstance(render_params.cmap_params, list):
@@ -498,11 +493,7 @@ def _render_images(
                     "Consider using 'palette' instead."
                 )
 
-            im = ax.imshow(
-                stacked,
-                alpha=render_params.alpha,
-            )
-            im.set_transform(trans_data)
+            ax_show_and_transform(stacked, trans_data, ax, render_params.alpha)
 
         # 2B) Image has n channels, no palette/cmap info -> sample n categorical colors
         elif palette is None and not got_multiple_cmaps:
@@ -520,11 +511,7 @@ def _render_images(
             # Remove alpha channel so we can overwrite it from render_params.alpha
             colored = colored[:, :, :3]
 
-            im = ax.imshow(
-                colored,
-                alpha=render_params.alpha,
-            )
-            im.set_transform(trans_data)
+            ax_show_and_transform(colored, trans_data, ax, render_params.alpha)
 
         # 2C) Image has n channels and palette info
         elif palette is not None and not got_multiple_cmaps:
@@ -539,11 +526,7 @@ def _render_images(
             # Remove alpha channel so we can overwrite it from render_params.alpha
             colored = colored[:, :, :3]
 
-            im = ax.imshow(
-                colored,
-                alpha=render_params.alpha,
-            )
-            im.set_transform(trans_data)
+            ax_show_and_transform(colored, trans_data, ax, render_params.alpha)
 
         elif palette is None and got_multiple_cmaps:
             channel_cmaps = [cp.cmap for cp in render_params.cmap_params]  # type: ignore[union-attr]
@@ -556,11 +539,7 @@ def _render_images(
             # Remove alpha channel so we can overwrite it from render_params.alpha
             colored = colored[:, :, :3]
 
-            im = ax.imshow(
-                colored,
-                alpha=render_params.alpha,
-            )
-            im.set_transform(trans_data)
+            ax_show_and_transform(colored, trans_data, ax, render_params.alpha)
 
         elif palette is not None and got_multiple_cmaps:
             raise ValueError("If 'palette' is provided, 'cmap' must be None.")

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -374,211 +374,198 @@ def _render_images(
     legend_params: LegendParams,
     rasterize: bool,
 ) -> None:
-    elements = render_params.elements
-    palettes = _return_list_list_str_none(render_params.palette)
 
     sdata_filt = sdata.filter_by_coordinate_system(
         coordinate_system=coordinate_system,
         filter_tables=False,
     )
 
-    if elements is None:
-        elements = list(sdata_filt.images.keys())
+    palette = render_params.palette
+    img = sdata_filt[render_params.element]
+    extent = get_extent(img, coordinate_system=coordinate_system)
+    scale = render_params.scale
 
-    for i, e in enumerate(elements):
-        img = sdata.images[e]
-        extent = get_extent(img, coordinate_system=coordinate_system)
-        scale = render_params.scale[i] if isinstance(render_params.scale, list) else render_params.scale
+    # get best scale out of multiscale image
+    if isinstance(img, MultiscaleSpatialImage):
+        img = _multiscale_to_spatial_image(
+            multiscale_image=img,
+            dpi=fig_params.fig.dpi,
+            width=fig_params.fig.get_size_inches()[0],
+            height=fig_params.fig.get_size_inches()[1],
+            scale=scale,
+        )
+    # rasterize spatial image if necessary to speed up performance
+    if rasterize:
+        img = _rasterize_if_necessary(
+            image=img,
+            dpi=fig_params.fig.dpi,
+            width=fig_params.fig.get_size_inches()[0],
+            height=fig_params.fig.get_size_inches()[1],
+            coordinate_system=coordinate_system,
+            extent=extent,
+        )
 
-        # get best scale out of multiscale image
-        if isinstance(img, MultiscaleSpatialImage):
-            img = _multiscale_to_spatial_image(
-                multiscale_image=img,
-                dpi=fig_params.fig.dpi,
-                width=fig_params.fig.get_size_inches()[0],
-                height=fig_params.fig.get_size_inches()[1],
-                scale=scale,
+    channels = img.coords["c"].values if render_params.channel is None else render_params.channel
+
+    n_channels = len(channels)
+
+    # True if user gave n cmaps for n channels
+    got_multiple_cmaps = isinstance(render_params.cmap_params, list)
+    if got_multiple_cmaps:
+        logger.warning(
+            "You're blending multiple cmaps. "
+            "If the plot doesn't look like you expect, it might be because your "
+            "cmaps go from a given color to 'white', and not to 'transparent'. "
+            "Therefore, the 'white' of higher layers will overlay the lower layers. "
+            "Consider using 'palette' instead."
+        )
+
+    # not using got_multiple_cmaps here because of ruff :(
+    if isinstance(render_params.cmap_params, list) and len(render_params.cmap_params) != n_channels:
+        raise ValueError("If 'cmap' is provided, its length must match the number of channels.")
+
+    # prepare transformations
+    trans = get_transformation(img, get_all=True)[coordinate_system]
+    affine_trans = trans.to_affine_matrix(input_axes=("x", "y"), output_axes=("x", "y"))
+    trans = mtransforms.Affine2D(matrix=affine_trans)
+    trans_data = trans + ax.transData
+
+    # 1) Image has only 1 channel
+    if n_channels == 1 and not isinstance(render_params.cmap_params, list):
+        layer = img.sel(c=channels[0]).squeeze()
+
+        if render_params.percentiles_for_norm != (None, None):
+            layer = _normalize(
+                layer, pmin=render_params.percentiles_for_norm[0], pmax=render_params.percentiles_for_norm[1], clip=True
             )
-        # rasterize spatial image if necessary to speed up performance
-        if rasterize:
-            img = _rasterize_if_necessary(
-                image=img,
-                dpi=fig_params.fig.dpi,
-                width=fig_params.fig.get_size_inches()[0],
-                height=fig_params.fig.get_size_inches()[1],
-                coordinate_system=coordinate_system,
-                extent=extent,
-            )
 
-        if render_params.channel is None:
-            channels = img.coords["c"].values
-        else:
-            channels = (
-                [render_params.channel] if isinstance(render_params.channel, (str, int)) else render_params.channel
-            )
+        if render_params.cmap_params.norm:  # type: ignore[attr-defined]
+            layer = render_params.cmap_params.norm(layer)  # type: ignore[attr-defined]
 
-        n_channels = len(channels)
+        cmap = (
+            render_params.cmap_params.cmap if render_params.palette is None else _get_linear_colormap(palette, "k")[0]
+        )
 
-        # True if user gave n cmaps for n channels
-        got_multiple_cmaps = isinstance(render_params.cmap_params, list)
-        if got_multiple_cmaps:
-            logger.warning(
-                "You're blending multiple cmaps. "
-                "If the plot doesn't look like you expect, it might be because your "
-                "cmaps go from a given color to 'white', and not to 'transparent'. "
-                "Therefore, the 'white' of higher layers will overlay the lower layers. "
-                "Consider using 'palette' instead."
-            )
+        # Overwrite alpha in cmap: https://stackoverflow.com/a/10127675
+        cmap._init()
+        cmap._lut[:, -1] = render_params.alpha
 
-        # not using got_multiple_cmaps here because of ruff :(
-        if isinstance(render_params.cmap_params, list) and len(render_params.cmap_params) != n_channels:
-            raise ValueError("If 'cmap' is provided, its length must match the number of channels.")
+        im = ax.imshow(
+            layer,
+            cmap=cmap,
+        )
+        im.set_transform(trans_data)
 
-        # prepare transformations
-        trans = get_transformation(img, get_all=True)[coordinate_system]
-        affine_trans = trans.to_affine_matrix(input_axes=("x", "y"), output_axes=("x", "y"))
-        trans = mtransforms.Affine2D(matrix=affine_trans)
-        trans_data = trans + ax.transData
+    # 2) Image has any number of channels but 1
+    else:
+        layers = {}
+        for ch_index, c in enumerate(channels):
+            layers[c] = img.sel(c=c).copy(deep=True).squeeze()
 
-        # 1) Image has only 1 channel
-        if n_channels == 1 and not isinstance(render_params.cmap_params, list):
-            layer = img.sel(c=channels[0]).squeeze()
-
-            if render_params.quantiles_for_norm != (None, None):
-                layer = _normalize(
-                    layer, pmin=render_params.quantiles_for_norm[0], pmax=render_params.quantiles_for_norm[1], clip=True
+            if render_params.percentiles_for_norm != (None, None):
+                layers[c] = _normalize(
+                    layers[c],
+                    pmin=render_params.percentiles_for_norm[0],
+                    pmax=render_params.percentiles_for_norm[1],
+                    clip=True,
                 )
 
-            if render_params.cmap_params.norm is not None:  # type: ignore[attr-defined]
-                layer = render_params.cmap_params.norm(layer)  # type: ignore[attr-defined]
+            if not isinstance(render_params.cmap_params, list):
+                if render_params.cmap_params.norm:
+                    layers[c] = render_params.cmap_params.norm(layers[c])
+            else:
+                if render_params.cmap_params[ch_index].norm:
+                    layers[c] = render_params.cmap_params[ch_index].norm(layers[c])
 
-            if isinstance(palettes, list):
-                if palettes[i][0] is None:
-                    cmap = render_params.cmap_params.cmap  # type: ignore[attr-defined]
-                else:
-                    cmap = _get_linear_colormap(palettes[i], "k")[0]  # type: ignore[arg-type]
-
-            # Overwrite alpha in cmap: https://stackoverflow.com/a/10127675
-            cmap._init()
-            cmap._lut[:, -1] = render_params.alpha
-
-            im = ax.imshow(
-                layer,
-                cmap=cmap,
-            )
-            im.set_transform(trans_data)
-
-        # 2) Image has any number of channels but 1
-        else:
-            layers = {}
-            for ch_index, c in enumerate(channels):
-                layers[c] = img.sel(c=c).copy(deep=True).squeeze()
-
-                if render_params.quantiles_for_norm != (None, None):
-                    layers[c] = _normalize(
-                        layers[c],
-                        pmin=render_params.quantiles_for_norm[0],
-                        pmax=render_params.quantiles_for_norm[1],
-                        clip=True,
-                    )
-
-                if not isinstance(render_params.cmap_params, list):
-                    if render_params.cmap_params.norm is not None:
-                        layers[c] = render_params.cmap_params.norm(layers[c])
-                else:
-                    if render_params.cmap_params[ch_index].norm is not None:
-                        layers[c] = render_params.cmap_params[ch_index].norm(layers[c])
-
-            # 2A) Image has 3 channels, no palette info, and no/only one cmap was given
-            if isinstance(palettes, list):
-                if n_channels == 3 and palettes[i][0] is None and not isinstance(render_params.cmap_params, list):
-                    if render_params.cmap_params.is_default:  # -> use RGB
-                        stacked = np.stack([layers[c] for c in channels], axis=-1)
-                    else:  # -> use given cmap for each channel
-                        channel_cmaps = [render_params.cmap_params.cmap] * n_channels
-                        # Apply cmaps to each channel, add up and normalize to [0, 1]
-                        stacked = (
-                            np.stack([channel_cmaps[ind](layers[ch]) for ind, ch in enumerate(channels)], 0).sum(0)
-                            / n_channels
-                        )
-                        # Remove alpha channel so we can overwrite it from render_params.alpha
-                        stacked = stacked[:, :, :3]
-                        logger.warning(
-                            "One cmap was given for multiple channels and is now used for each channel. "
-                            "You're blending multiple cmaps. "
-                            "If the plot doesn't look like you expect, it might be because your "
-                            "cmaps go from a given color to 'white', and not to 'transparent'. "
-                            "Therefore, the 'white' of higher layers will overlay the lower layers. "
-                            "Consider using 'palette' instead."
-                        )
-
-                    im = ax.imshow(
-                        stacked,
-                        alpha=render_params.alpha,
-                    )
-                    im.set_transform(trans_data)
-
-                # 2B) Image has n channels, no palette/cmap info -> sample n categorical colors
-                elif palettes[i][0] is None and not got_multiple_cmaps:
-                    # overwrite if n_channels == 2 for intuitive result
-                    if n_channels == 2:
-                        seed_colors = ["#ff0000ff", "#00ff00ff"]
-                    else:
-                        seed_colors = _get_colors_for_categorical_obs(list(range(n_channels)))
-
-                    channel_cmaps = [_get_linear_colormap([c], "k")[0] for c in seed_colors]
-
-                    # Apply cmaps to each channel and add up
-                    colored = np.stack([channel_cmaps[ind](layers[ch]) for ind, ch in enumerate(channels)], 0).sum(0)
-
-                    # Remove alpha channel so we can overwrite it from render_params.alpha
-                    colored = colored[:, :, :3]
-
-                    im = ax.imshow(
-                        colored,
-                        alpha=render_params.alpha,
-                    )
-                    im.set_transform(trans_data)
-
-                # 2C) Image has n channels and palette info
-                elif palettes[i][0] is not None and not got_multiple_cmaps:
-                    if len(palettes[i]) != n_channels:
-                        raise ValueError("If 'palette' is provided, its length must match the number of channels.")
-
-                    channel_cmaps = [_get_linear_colormap([c], "k")[0] for c in palettes[i] if isinstance(c, str)]
-
-                    # Apply cmaps to each channel and add up
-                    colored = np.stack([channel_cmaps[i](layers[c]) for i, c in enumerate(channels)], 0).sum(0)
-
-                    # Remove alpha channel so we can overwrite it from render_params.alpha
-                    colored = colored[:, :, :3]
-
-                    im = ax.imshow(
-                        colored,
-                        alpha=render_params.alpha,
-                    )
-                    im.set_transform(trans_data)
-
-                elif palettes[i][0] is None and got_multiple_cmaps:
-                    channel_cmaps = [cp.cmap for cp in render_params.cmap_params]  # type: ignore[union-attr]
-
+        # 2A) Image has 3 channels, no palette info, and no/only one cmap was given
+        if isinstance(palette := render_params.palette, list):
+            if n_channels == 3 and palette[0] is None and not isinstance(render_params.cmap_params, list):
+                if render_params.cmap_params.is_default:  # -> use RGB
+                    stacked = np.stack([layers[c] for c in channels], axis=-1)
+                else:  # -> use given cmap for each channel
+                    channel_cmaps = [render_params.cmap_params.cmap] * n_channels
                     # Apply cmaps to each channel, add up and normalize to [0, 1]
-                    colored = (
+                    stacked = (
                         np.stack([channel_cmaps[ind](layers[ch]) for ind, ch in enumerate(channels)], 0).sum(0)
                         / n_channels
                     )
-
                     # Remove alpha channel so we can overwrite it from render_params.alpha
-                    colored = colored[:, :, :3]
-
-                    im = ax.imshow(
-                        colored,
-                        alpha=render_params.alpha,
+                    stacked = stacked[:, :, :3]
+                    logger.warning(
+                        "One cmap was given for multiple channels and is now used for each channel. "
+                        "You're blending multiple cmaps. "
+                        "If the plot doesn't look like you expect, it might be because your "
+                        "cmaps go from a given color to 'white', and not to 'transparent'. "
+                        "Therefore, the 'white' of higher layers will overlay the lower layers. "
+                        "Consider using 'palette' instead."
                     )
-                    im.set_transform(trans_data)
 
-                elif palettes[i][0] is not None and got_multiple_cmaps:
-                    raise ValueError("If 'palette' is provided, 'cmap' must be None.")
+                im = ax.imshow(
+                    stacked,
+                    alpha=render_params.alpha,
+                )
+                im.set_transform(trans_data)
+
+        # 2B) Image has n channels, no palette/cmap info -> sample n categorical colors
+        elif palette is None and not got_multiple_cmaps:
+            # overwrite if n_channels == 2 for intuitive result
+            if n_channels == 2:
+                seed_colors = ["#ff0000ff", "#00ff00ff"]
+            else:
+                seed_colors = _get_colors_for_categorical_obs(list(range(n_channels)))
+
+            channel_cmaps = [_get_linear_colormap([c], "k")[0] for c in seed_colors]
+
+            # Apply cmaps to each channel and add up
+            colored = np.stack([channel_cmaps[ind](layers[ch]) for ind, ch in enumerate(channels)], 0).sum(0)
+
+            # Remove alpha channel so we can overwrite it from render_params.alpha
+            colored = colored[:, :, :3]
+
+            im = ax.imshow(
+                colored,
+                alpha=render_params.alpha,
+            )
+            im.set_transform(trans_data)
+
+        # 2C) Image has n channels and palette info
+        elif palette is not None and not got_multiple_cmaps:
+            if len(palette) != n_channels:
+                raise ValueError("If 'palette' is provided, its length must match the number of channels.")
+
+            channel_cmaps = [_get_linear_colormap([c], "k")[0] for c in palette if isinstance(c, str)]
+
+            # Apply cmaps to each channel and add up
+            colored = np.stack([channel_cmaps[i](layers[c]) for i, c in enumerate(channels)], 0).sum(0)
+
+            # Remove alpha channel so we can overwrite it from render_params.alpha
+            colored = colored[:, :, :3]
+
+            im = ax.imshow(
+                colored,
+                alpha=render_params.alpha,
+            )
+            im.set_transform(trans_data)
+
+        elif palette is None and got_multiple_cmaps:
+            channel_cmaps = [cp.cmap for cp in render_params.cmap_params]  # type: ignore[union-attr]
+
+            # Apply cmaps to each channel, add up and normalize to [0, 1]
+            colored = (
+                np.stack([channel_cmaps[ind](layers[ch]) for ind, ch in enumerate(channels)], 0).sum(0) / n_channels
+            )
+
+            # Remove alpha channel so we can overwrite it from render_params.alpha
+            colored = colored[:, :, :3]
+
+            im = ax.imshow(
+                colored,
+                alpha=render_params.alpha,
+            )
+            im.set_transform(trans_data)
+
+        elif palette is not None and got_multiple_cmaps:
+            raise ValueError("If 'palette' is provided, 'cmap' must be None.")
 
 
 def _render_labels(

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -34,7 +34,6 @@ from spatialdata_plot.pl.render_params import (
     ShapesRenderParams,
 )
 from spatialdata_plot.pl.utils import (
-    ax_show_and_transform,
     _decorate_axs,
     _get_collection_shape,
     _get_colors_for_categorical_obs,
@@ -48,6 +47,7 @@ from spatialdata_plot.pl.utils import (
     _return_list_list_str_none,
     _return_list_str_none,
     _set_color_source_vec,
+    ax_show_and_transform,
     to_hex,
 )
 
@@ -451,7 +451,7 @@ def _render_images(
         cmap._init()
         cmap._lut[:, -1] = render_params.alpha
 
-        ax_show_and_transform(layer,trans_data, ax, cmap=cmap)
+        ax_show_and_transform(layer, trans_data, ax, cmap=cmap)
 
     # 2) Image has any number of channels but 1
     else:

--- a/src/spatialdata_plot/pl/render_params.py
+++ b/src/spatialdata_plot/pl/render_params.py
@@ -70,7 +70,7 @@ class ShapesRenderParams:
 
     cmap_params: CmapParams
     outline_params: OutlineParams
-    elements: str | Sequence[str] | None = None
+    elements: str | list[str] | None = None
     color: list[str | None] | str | None = None
     col_for_color: str | None = None
     groups: str | list[list[str | None]] | list[str | None] | None = None
@@ -104,12 +104,12 @@ class ImageRenderParams:
     """Labels render parameters.."""
 
     cmap_params: list[CmapParams] | CmapParams
-    element: str | Sequence[str] | None = None
+    element: str
     channel: list[str] | list[int] | int | str | None = None
-    palette: ListedColormap | list[list[str | None]] | list[str | None] | None = None
+    palette: ListedColormap | list[str] | None = None
     alpha: float = 1.0
     percentiles_for_norm: tuple[float | None, float | None] = (None, None)
-    scale: str | list[str] | None = None
+    scale: str | None = None
 
 
 @dataclass
@@ -117,7 +117,7 @@ class LabelsRenderParams:
     """Labels render parameters.."""
 
     cmap_params: CmapParams
-    elements: str | Sequence[str] | None = None
+    elements: str | list[str] | None = None
     color: list[str | None] | str | None = None
     groups: str | list[list[str | None]] | list[str | None] | None = None
     contour_px: int | None = None

--- a/src/spatialdata_plot/pl/render_params.py
+++ b/src/spatialdata_plot/pl/render_params.py
@@ -108,7 +108,7 @@ class ImageRenderParams:
     channel: list[str] | list[int] | int | str | None = None
     palette: ListedColormap | list[list[str | None]] | list[str | None] | None = None
     alpha: float = 1.0
-    quantiles_for_norm: tuple[float | None, float | None] = (None, None)
+    percentiles_for_norm: tuple[float | None, float | None] = (None, None)
     scale: str | list[str] | None = None
 
 

--- a/src/spatialdata_plot/pl/render_params.py
+++ b/src/spatialdata_plot/pl/render_params.py
@@ -104,7 +104,7 @@ class ImageRenderParams:
     """Labels render parameters.."""
 
     cmap_params: list[CmapParams] | CmapParams
-    elements: str | Sequence[str] | None = None
+    element: str | Sequence[str] | None = None
     channel: list[str] | list[int] | int | str | None = None
     palette: ListedColormap | list[list[str | None]] | list[str | None] | None = None
     alpha: float = 1.0

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1347,7 +1347,7 @@ def _get_elements_to_be_rendered(
         key = render_cmds_map.get(cmd)
         # TODO: change after completion of refactor to single element configs
         if cmd == "render_images" and isinstance(params, ImageRenderParams):
-            elements_to_be_rendered = [params.element]
+            elements_to_be_rendered += [params.element]
         if key and cs_query[key][0] and not isinstance(params, ImageRenderParams) and params.elements is not None:
             elements_to_be_rendered += [params.elements] if isinstance(params.elements, str) else params.elements
     return elements_to_be_rendered

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2174,3 +2174,17 @@ def _return_list_list_str_none(
         return [list(sublist) for sublist in parameter if isinstance(sublist, list)]
 
     return [[None]]
+
+def ax_show_and_transform(array, trans_data, ax, alpha=None, cmap=None):
+    if not cmap and alpha is not None:
+        im = ax.imshow(
+            array,
+            alpha=alpha,
+        )
+        im.set_transform(trans_data)
+    else:
+        im = ax.imshow(
+            array,
+            cmap=cmap,
+        )
+        im.set_transform(trans_data)

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1671,16 +1671,18 @@ def _type_check_params(param_dict: dict[str, Any], element_type: str) -> dict[st
 
     palette = param_dict["palette"]
 
-    if isinstance(palette, list) and not all(isinstance(p, str) for p in palette):
-        raise ValueError("If specified, parameter 'palette' must contain only strings.")
-    if isinstance(palette, (str, type(None))):
+    if isinstance(palette, list):
+        if not all(isinstance(p, str) for p in palette):
+            raise ValueError("If specified, parameter 'palette' must contain only strings.")
+    elif isinstance(palette, (str, type(None))):
         param_dict["palette"] = [palette] if palette is not None else None
     else:
         raise TypeError("Invalid type of parameter 'palette'. Must be `str` or `list[str]`.")
 
-    if isinstance(cmap, list) and not all(isinstance(c, (Colormap, str)) for c in cmap):
-        raise TypeError("Each item in 'cmap' list must be a string or a Colormap.")
-    if isinstance(cmap, (Colormap, str, type(None))):
+    if isinstance(cmap, list):
+        if not all(isinstance(c, (Colormap, str)) for c in cmap):
+            raise TypeError("Each item in 'cmap' list must be a string or a Colormap.")
+    elif isinstance(cmap, (Colormap, str, type(None))):
         param_dict["cmap"] = [cmap] if cmap is not None else None
     else:
         raise TypeError("Parameter 'cmap' must be a string, a Colormap, or a list of these types.")
@@ -1754,10 +1756,10 @@ def _validate_image_render_params(
         spatial_element_ch = (
             spatial_element.c if isinstance(spatial_element, SpatialImage) else spatial_element["scale0"].c
         )
-        if (
-            isinstance((channel := param_dict["channel"])[0], int)
-            and max([abs(ch) for ch in channel]) <= len(spatial_element_ch)
-        ) or all(ch in spatial_element_ch for ch in channel):
+        if (channel := param_dict["channel"]) is not None and (
+            (isinstance(channel[0], int) and max([abs(ch) for ch in channel]) <= len(spatial_element_ch))
+            or all(ch in spatial_element_ch for ch in channel)
+        ):
             element_params[el]["channel"] = channel
         else:
             element_params[el]["channel"] = None
@@ -1768,7 +1770,7 @@ def _validate_image_render_params(
             if len(palette) == 1:
                 palette_length = len(channel) if channel is not None else len(spatial_element.c)
                 palette = palette * palette_length
-            if (channel is not None and len(palette) != len(channel)) or len(palette) != len(spatial_element.c):
+            if (channel is not None and len(palette) != len(channel)) and len(palette) != len(spatial_element.c):
                 palette = None
         element_params[el]["palette"] = palette
         element_params[el]["na_color"] = param_dict["na_color"]

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1343,7 +1343,10 @@ def _get_elements_to_be_rendered(
 
     for cmd, params in render_cmds:
         key = render_cmds_map.get(cmd)
-        if key and cs_query[key][0] and params.elements is not None:
+        # TODO: change after completion of refactor to single element configs
+        if cmd == "render_images" and isinstance(params, ImageRenderParams):
+            elements_to_be_rendered = [params.element]
+        if key and cs_query[key][0] and not isinstance(params, ImageRenderParams) and params.elements is not None:
             elements_to_be_rendered += [params.elements] if isinstance(params.elements, str) else params.elements
     return elements_to_be_rendered
 
@@ -1639,6 +1642,158 @@ def _validate_show_parameters(
         raise TypeError("Parameter 'save' must be a string or a pathlib.Path.")
 
 
+def _type_check_params(param_dict: dict[str, Any], element_type: str) -> dict[str, Any]:
+    if (element := param_dict["element"]) is not None and not isinstance(element, str):
+        raise ValueError(
+            "Parameter 'element' must be a string. If you want to display more elements, pass `element` "
+            "as `None` or chain pl.render(...).pl.render(...).pl.show()"
+        )
+    param_dict["element"] = [element] if element is not None else list(param_dict["sdata"].images.keys())
+
+    if (channel := param_dict["channel"]) is not None and not isinstance(channel, (list, str, int)):
+        raise TypeError("Parameter 'channel' must be a string, an integer, or a list of strings or integers.")
+    if isinstance(channel, list):
+        if not all(isinstance(c, (str, int)) for c in channel):
+            raise TypeError("Each item in 'channel' list must be a string or an integer.")
+        if not all(isinstance(c, type(channel[0])) for c in channel):
+            raise TypeError("Each item in 'channel' list must be of the same type, either string or integer.")
+    else:
+        param_dict["channel"] = [channel] if channel is not None else None
+
+    if (alpha := param_dict["alpha"]) is not None:
+        if not isinstance(alpha, (float, int)):
+            raise TypeError("Parameter 'alpha' must be numeric.")
+        if not 0 <= alpha <= 1:
+            raise ValueError("Parameter 'alpha' must be between 0 and 1.")
+
+    if (cmap := param_dict["cmap"]) is not None and (palette := param_dict["palette"]) is not None:
+        raise ValueError("Both `palette` and `cmap` are specified. Please specify only one of them.")
+
+    palette = param_dict["palette"]
+
+    if isinstance(palette, list) and not all(isinstance(p, str) for p in palette):
+        raise ValueError("If specified, parameter 'palette' must contain only strings.")
+    if isinstance(palette, (str, type(None))):
+        param_dict["palette"] = [palette] if palette is not None else None
+    else:
+        raise TypeError("Invalid type of parameter 'palette'. Must be `str` or `list[str]`.")
+
+    if isinstance(cmap, list) and not all(isinstance(c, (Colormap, str)) for c in cmap):
+        raise TypeError("Each item in 'cmap' list must be a string or a Colormap.")
+    if isinstance(cmap, (Colormap, str, type(None))):
+        param_dict["cmap"] = [cmap] if cmap is not None else None
+    else:
+        raise TypeError("Parameter 'cmap' must be a string, a Colormap, or a list of these types.")
+
+    if (na_color := param_dict["na_color"]) is not None and not colors.is_color_like(na_color):
+        raise ValueError("Parameter 'na_color' must be color-like.")
+
+    if (norm := param_dict["norm"]) is not None and not isinstance(norm, Normalize):
+        raise TypeError("Parameter 'norm' must be of type Normalize.")
+
+    if (scale := param_dict["scale"]) is not None and not isinstance(scale, str):
+        raise TypeError("Parameter 'scale' must be a string if specified.")
+
+    if (percentiles_for_norm := param_dict["percentiles_for_norm"]) is None:
+        percentiles_for_norm = (None, None)
+    elif not (isinstance(percentiles_for_norm, (list, tuple)) or len(percentiles_for_norm) != 2):
+        raise TypeError("Parameter 'percentiles_for_norm' must be a list or tuple of exactly two floats or None.")
+    elif not all(
+        isinstance(p, (float, int, type(None)))
+        and isinstance(p, type(percentiles_for_norm[0]))
+        and (p is None or 0 <= p <= 100)
+        for p in percentiles_for_norm
+    ):
+        raise TypeError(
+            "Each item in 'percentiles_for_norm' must be of the same dtype and must be a float or int within [0, 100], "
+            "or None"
+        )
+    elif (
+        percentiles_for_norm[0] is not None
+        and percentiles_for_norm[1] is not None
+        and percentiles_for_norm[0] > percentiles_for_norm[1]
+    ):
+        raise ValueError("The first number in 'quantiles_for_norm' must not be smaller than the second.")
+
+    param_dict["percentiles_for_norm"] = percentiles_for_norm
+
+    return param_dict
+
+
+def _validate_image_render_params(
+    sdata: sd.SpatialData,
+    element: str | None,
+    channel: list[str] | list[int] | str | int | None,
+    alpha: float | int | None,
+    palette: list[str] | None,
+    na_color: ColorLike | None,
+    cmap: list[Colormap | str] | Colormap | str | None,
+    norm: Normalize | None,
+    scale: str | None,
+    percentiles_for_norm: tuple[float | None, float | None] | None,
+) -> dict[str]:
+    param_dict: dict[str, Any] = {
+        "sdata": sdata,
+        "element": element,
+        "channel": channel,
+        "alpha": alpha,
+        "palette": palette,
+        "na_color": na_color,
+        "cmap": cmap,
+        "norm": norm,
+        "scale": scale,
+        "percentiles_for_norm": percentiles_for_norm,
+    }
+    param_dict = _type_check_params(param_dict, "images")
+
+    element_params = {}
+    for el in param_dict["element"]:
+        element_params[el] = {}
+        spatial_element = param_dict["sdata"][el]
+
+        spatial_element_ch = (
+            spatial_element.c if isinstance(spatial_element, SpatialImage) else spatial_element["scale0"].c
+        )
+        if (
+            isinstance((channel := param_dict["channel"])[0], int)
+            and max([abs(ch) for ch in channel]) <= len(spatial_element_ch)
+        ) or all(ch in spatial_element_ch for ch in channel):
+            element_params[el]["channel"] = channel
+        else:
+            element_params[el]["channel"] = None
+
+        element_params[el]["alpha"] = param_dict["alpha"]
+
+        if (palette := param_dict["palette"]) is not None:
+            if len(palette) == 1:
+                palette_length = len(channel) if channel is not None else len(spatial_element.c)
+                palette = palette * palette_length
+            if (channel is not None and len(palette) != len(channel)) or len(palette) != len(spatial_element.c):
+                palette = None
+        element_params[el]["palette"] = palette
+        element_params[el]["na_color"] = param_dict["na_color"]
+
+        if (cmap := param_dict["cmap"]) is not None:
+            if len(cmap) == 1:
+                cmap_length = len(channel) if channel is not None else len(spatial_element.c)
+                cmap = cmap * cmap_length
+            if (channel is not None and len(cmap) != len(channel)) or len(cmap) != len(spatial_element.c):
+                cmap = None
+        element_params[el]["cmap"] = cmap
+        element_params[el]["norm"] = param_dict["norm"]
+        if (scale := param_dict["scale"]) and isinstance(sdata[el], MultiscaleSpatialImage):
+            if scale not in list(sdata[el].keys()) and scale != "full":
+                element_params[el]["scale"] = None
+            else:
+                element_params[el]["scale"] = scale
+        else:
+            element_params[el]["scale"] = None
+
+        element_params[el]["percentiles_for_norm"] = param_dict["percentiles_for_norm"]
+
+    return element_params
+
+
 def _validate_render_params(
     element_type: str,
     sdata: sd.SpatialData,
@@ -1907,40 +2062,35 @@ def _validate_render_params(
 
 
 def _match_length_elements_groups_palette(
-    params: ImageRenderParams | LabelsRenderParams | PointsRenderParams | ShapesRenderParams,
+    params: LabelsRenderParams | PointsRenderParams | ShapesRenderParams,
     render_elements: list[str],
     image: bool = False,
-) -> ImageRenderParams | LabelsRenderParams | PointsRenderParams | ShapesRenderParams:
-    if image and isinstance(params, ImageRenderParams):
-        if params.palette is None:
-            params.palette = [[None] for _ in range(len(render_elements))]
-        else:
-            params.palette = [params.palette[0] for _ in range(len(render_elements))]
-    elif not isinstance(params, ImageRenderParams):
-        groups = params.groups
-        palette = params.palette
+) -> LabelsRenderParams | PointsRenderParams | ShapesRenderParams:
 
-        groups_elements: list[list[str | None]] | None = None
-        palette_elements: list[list[str | None]] | None = None
-        # We already checked before that length of groups and palette is the same
-        if groups is not None:
-            if len(groups) == 1:
-                groups_elements = [groups[0] for _ in range(len(render_elements)) if isinstance(groups[0], list)]
-                if palette is not None:
-                    palette_elements = [palette[0] for _ in range(len(render_elements)) if isinstance(palette[0], list)]
-                else:
-                    palette_elements = [[None] for _ in range(len(render_elements))]
+    groups = params.groups
+    palette = params.palette
+
+    groups_elements: list[list[str | None]] | None = None
+    palette_elements: list[list[str | None]] | None = None
+    # We already checked before that length of groups and palette is the same
+    if groups is not None:
+        if len(groups) == 1:
+            groups_elements = [groups[0] for _ in range(len(render_elements)) if isinstance(groups[0], list)]
+            if palette is not None:
+                palette_elements = [palette[0] for _ in range(len(render_elements)) if isinstance(palette[0], list)]
             else:
-                if len(groups) != len(render_elements):
-                    raise ValueError(
-                        "Multiple groups and palettes are given but the number is not the same as the number "
-                        "of elements to be rendered."
-                    )
+                palette_elements = [[None] for _ in range(len(render_elements))]
         else:
-            groups_elements = [[None] for _ in range(len(render_elements))]
-            palette_elements = [[None] for _ in range(len(render_elements))]
-        params.palette = palette_elements
-        params.groups = groups_elements
+            if len(groups) != len(render_elements):
+                raise ValueError(
+                    "Multiple groups and palettes are given but the number is not the same as the number "
+                    "of elements to be rendered."
+                )
+    else:
+        groups_elements = [[None] for _ in range(len(render_elements))]
+        palette_elements = [[None] for _ in range(len(render_elements))]
+    params.palette = palette_elements
+    params.groups = groups_elements
 
     return params
 
@@ -1954,7 +2104,16 @@ def _get_wanted_render_elements(
 ) -> tuple[list[str], list[str], bool]:
     wants_elements = True
     if element_type in ["images", "labels", "points", "shapes"]:  # Prevents eval security risk
-        wanted_elements = params.elements if params.elements is not None else list(getattr(sdata, element_type).keys())
+        # TODO: Remove this when the refactor to single element configs is completed
+        if element_type == "images":
+            wanted_elements = params.element
+        else:
+            wanted_elements = (
+                params.elements if params.elements is not None else list(getattr(sdata, element_type).keys())
+            )
+
+        # TODO: Remove this when the refactor to single element configs is completed
+        wanted_elements = [wanted_elements] if isinstance(wanted_elements, str) else wanted_elements
 
         wanted_elements_on_cs = [
             element for element in wanted_elements if cs in set(get_transformation(sdata[element], get_all=True).keys())
@@ -1979,8 +2138,11 @@ def _update_params(
         if isinstance(params, (PointsRenderParams, ShapesRenderParams)):
             params = _validate_colors_element_table_mapping_points_shapes(sdata, params, wanted_elements_on_cs)
 
-    image_flag = element_type == "images"
-    return _match_length_elements_groups_palette(params, wanted_elements_on_cs, image=image_flag)
+    # TODO change after completion refactor
+    if element_type == "images":
+        return params
+
+    return _match_length_elements_groups_palette(params, wanted_elements_on_cs)
 
 
 def _is_coercable_to_float(series: pd.Series) -> bool:

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2175,6 +2175,7 @@ def _return_list_list_str_none(
 
     return [[None]]
 
+
 def ax_show_and_transform(array, trans_data, ax, alpha=None, cmap=None):
     if not cmap and alpha is not None:
         im = ax.imshow(


### PR DESCRIPTION
This PR refactors the way the parameters for image rendering get validated and passed. Some of the changes are not backward compatible. For `element` the user can't pass on a `list` of `str` anymore, but only `str` or `None`. All the passed on parameters are used to create a view config for a single element. If `element` is `None` then all the parameters are checked for whether they are valid for a specific element and if that is not the case the value of the parameter for that element is set to None. If a user wants to plot multiple specific images, the `pl.render` calls can be chained. 

Because of creating viewconfigs in such a way that each element has its own contained config this will make it easy to hook up vega like specifications and also to write those out.