### PR TITLE
Adjusts spatialdata-plot to use DataArray and DataTree

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -14,14 +14,14 @@ import scanpy as sc
 import spatialdata as sd
 from anndata import AnnData
 from dask.dataframe.core import DataFrame as DaskDataFrame
+from datatree import DataTree
 from geopandas import GeoDataFrame
 from matplotlib.axes import Axes
 from matplotlib.colors import Colormap, Normalize
 from matplotlib.figure import Figure
-from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
-from spatial_image import SpatialImage
 from spatialdata._core.data_extent import get_extent
-from spatialdata._utils import deprecation_alias
+from spatialdata._utils import _deprecation_alias
+from xarray import DataArray
 
 from spatialdata_plot._accessor import register_spatial_data_accessor
 from spatialdata_plot.pl.render import (
@@ -95,8 +95,8 @@ class PlotAccessor:
 
     def _copy(
         self,
-        images: dict[str, SpatialImage | MultiscaleSpatialImage] | None = None,
-        labels: dict[str, SpatialImage | MultiscaleSpatialImage] | None = None,
+        images: dict[str, DataArray | DataTree] | None = None,
+        labels: dict[str, DataArray | DataTree] | None = None,
         points: dict[str, DaskDataFrame] | None = None,
         shapes: dict[str, GeoDataFrame] | None = None,
         tables: dict[str, AnnData] | None = None,
@@ -105,11 +105,11 @@ class PlotAccessor:
 
         Parameters
         ----------
-        images : dict[str, SpatialImage | MultiscaleSpatialImage] | None, optional
+        images : dict[str, DataArray | DataTree] | None, optional
             A dictionary containing image data to replace the images in the
             original `SpatialData` object, or `None` to keep the original
             images. Defaults to `None`.
-        labels : dict[str, SpatialImage | MultiscaleSpatialImage] | None, optional
+        labels : dict[str, DataArray | DataTree] | None, optional
             A dictionary containing label data to replace the labels in the
             original `SpatialData` object, or `None` to keep the original
             labels. Defaults to `None`.
@@ -150,7 +150,7 @@ class PlotAccessor:
 
         return sdata
 
-    @deprecation_alias(elements="element", version="0.3.0")
+    @_deprecation_alias(elements="element", version="0.3.0")
     def render_shapes(
         self,
         element: str | None = None,
@@ -286,7 +286,7 @@ class PlotAccessor:
 
         return sdata
 
-    @deprecation_alias(elements="element", version="0.3.0")
+    @_deprecation_alias(elements="element", version="0.3.0")
     def render_points(
         self,
         element: str | None = None,
@@ -396,7 +396,7 @@ class PlotAccessor:
 
         return sdata
 
-    @deprecation_alias(elements="element", quantiles_for_norm="percentiles_for_norm", version="version 0.3.0")
+    @_deprecation_alias(elements="element", quantiles_for_norm="percentiles_for_norm", version="version 0.3.0")
     def render_images(
         self,
         element: str | None = None,
@@ -509,7 +509,7 @@ class PlotAccessor:
 
         return sdata
 
-    @deprecation_alias(elements="element", version="0.3.0")
+    @_deprecation_alias(elements="element", version="0.3.0")
     def render_labels(
         self,
         element: str | None = None,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -244,7 +244,10 @@ def _render_points(
         )
     else:
         adata = AnnData(
-            X=points[["x", "y"]].values, obs=sdata_filt[table_name].obs, dtype=points[["x", "y"]].values.dtype
+            X=points[["x", "y"]].values,
+            obs=sdata_filt[table_name].obs,
+            dtype=points[["x", "y"]].values.dtype,
+            uns=sdata_filt[table_name].uns,
         )
         sdata_filt[table_name] = adata
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -14,8 +14,8 @@ import pandas as pd
 import scanpy as sc
 import spatialdata as sd
 from anndata import AnnData
+from datatree import DataTree
 from matplotlib.colors import ListedColormap, Normalize
-from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
 from scanpy._settings import settings as sc_settings
 from spatialdata._core.data_extent import get_extent
 from spatialdata.models import PointsModel, get_table_keys
@@ -351,7 +351,7 @@ def _render_images(
     scale = render_params.scale
 
     # get best scale out of multiscale image
-    if isinstance(img, MultiscaleSpatialImage):
+    if isinstance(img, DataTree):
         img = _multiscale_to_spatial_image(
             multiscale_image=img,
             dpi=fig_params.fig.dpi,
@@ -541,7 +541,7 @@ def _render_labels(
     extent = get_extent(label, coordinate_system=coordinate_system)
 
     # get best scale out of multiscale label
-    if isinstance(label, MultiscaleSpatialImage):
+    if isinstance(label, DataTree):
         label = _multiscale_to_spatial_image(
             multiscale_image=label,
             dpi=fig_params.fig.dpi,

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -748,8 +748,8 @@ def _map_color_seg(
         cols = colors.to_rgba_array(color_vector.categories)
 
     else:
-        val_im = map_array(seg, cell_id, cell_id)  # replace with same seg id to remove missing segs
-
+        val_im = map_array(seg.copy(), cell_id, cell_id)  # replace with same seg id to remove missing segs
+        val_im = np.squeeze(val_im, axis=0)
         try:
             cols = cmap_params.cmap(cmap_params.norm(color_vector))
         except TypeError:
@@ -776,7 +776,8 @@ def _map_color_seg(
         seg_bound: ArrayLike = np.clip(seg_im - find_boundaries(seg)[:, :, None], 0, 1)
         return np.dstack((seg_bound, np.where(val_im > 0, 1, 0)))  # add transparency here
 
-    return np.dstack((seg_im, np.where(val_im > 0, 1, 0)))
+    val_im = np.expand_dims((val_im > 0).astype(int), axis=-1)
+    return np.dstack((seg_im, val_im))
 
 
 def _get_palette(

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -608,18 +608,6 @@ def _get_colors_for_categorical_obs(
     return palette[:len_cat]  # type: ignore[return-value]
 
 
-def _locate_points_value_in_table(value_key: str, sdata: SpatialData, table_name: str) -> _ValueOrigin:
-    table = sdata[table_name]
-
-    if value_key in table.obs.columns:
-        value = table.obs[value_key]
-        is_categorical = isinstance(value.dtype, CategoricalDtype)
-        return _ValueOrigin(origin="obs", is_categorical=is_categorical, value_key=value_key)
-
-    is_categorical = False
-    return _ValueOrigin(origin="var", is_categorical=is_categorical, value_key=value_key)
-
-
 # TODO consider move to relational query in spatialdata
 def get_values_point_table(sdata: SpatialData, origin: _ValueOrigin, table_name: str) -> pd.Series:
     """Get a particular column stored in _ValueOrigin from the table in the spatialdata object."""
@@ -650,10 +638,6 @@ def _set_color_source_vec(
 
     # Figure out where to get the color from
     origins = _locate_value(value_key=value_to_plot, sdata=sdata, element_name=element_name, table_name=table_name)
-    if model == PointsModel and table_name is not None:
-        origin = _locate_points_value_in_table(value_key=value_to_plot, sdata=sdata, table_name=table_name)
-        if origin is not None:
-            origins.append(origin)
 
     if len(origins) > 1:
         raise ValueError(
@@ -662,7 +646,7 @@ def _set_color_source_vec(
 
     if len(origins) == 1:
         if model == PointsModel and table_name is not None:
-            color_source_vector = get_values_point_table(sdata=sdata, origin=origin, table_name=table_name)
+            color_source_vector = get_values_point_table(sdata=sdata, origin=origins[0], table_name=table_name)
         else:
             vals = get_values(value_key=value_to_plot, sdata=sdata, element_name=element_name, table_name=table_name)
             color_source_vector = vals[value_to_plot]

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -749,7 +749,9 @@ def _map_color_seg(
 
     else:
         val_im = map_array(seg.copy(), cell_id, cell_id)  # replace with same seg id to remove missing segs
-        val_im = np.squeeze(val_im, axis=0)
+
+        if val_im.shape[0] == 1:
+            val_im = np.squeeze(val_im, axis=0)
         try:
             cols = cmap_params.cmap(cmap_params.norm(color_vector))
         except TypeError:
@@ -776,7 +778,8 @@ def _map_color_seg(
         seg_bound: ArrayLike = np.clip(seg_im - find_boundaries(seg)[:, :, None], 0, 1)
         return np.dstack((seg_bound, np.where(val_im > 0, 1, 0)))  # add transparency here
 
-    val_im = np.expand_dims((val_im > 0).astype(int), axis=-1)
+    if len(val_im.shape) != len(seg_im.shape):
+        val_im = np.expand_dims((val_im > 0).astype(int), axis=-1)
     return np.dstack((seg_im, val_im))
 
 

--- a/src/spatialdata_plot/pp/basic.py
+++ b/src/spatialdata_plot/pp/basic.py
@@ -4,10 +4,10 @@ from typing import Union
 import spatialdata as sd
 from anndata import AnnData
 from dask.dataframe.core import DataFrame as DaskDataFrame
+from datatree import DataTree
 from geopandas import GeoDataFrame
-from multiscale_spatial_image.multiscale_spatial_image import MultiscaleSpatialImage
-from spatial_image import SpatialImage
 from spatialdata.models import get_table_keys
+from xarray import DataArray
 
 from spatialdata_plot._accessor import register_spatial_data_accessor
 from spatialdata_plot.pp.utils import (
@@ -43,8 +43,8 @@ class PreprocessingAccessor:
 
     def _copy(
         self,
-        images: Union[None, dict[str, Union[SpatialImage, MultiscaleSpatialImage]]] = None,
-        labels: Union[None, dict[str, Union[SpatialImage, MultiscaleSpatialImage]]] = None,
+        images: Union[None, dict[str, Union[DataArray, DataTree]]] = None,
+        labels: Union[None, dict[str, Union[DataArray, DataTree]]] = None,
         points: Union[None, dict[str, DaskDataFrame]] = None,
         shapes: Union[None, dict[str, GeoDataFrame]] = None,
         tables: Union[None, dict[str, AnnData]] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,10 @@ import pytest
 import spatialdata as sd
 import spatialdata_plot  # noqa: F401
 from anndata import AnnData
+from datatree import DataTree
 from geopandas import GeoDataFrame
 from matplotlib.testing.compare import compare_images
-from multiscale_spatial_image import MultiscaleSpatialImage
 from shapely.geometry import MultiPolygon, Polygon
-from spatial_image import SpatialImage
 from spatialdata import SpatialData
 from spatialdata.datasets import blobs, raccoon
 from spatialdata.models import (
@@ -217,7 +216,7 @@ def sdata(request) -> SpatialData:
     return s
 
 
-def _get_images() -> dict[str, Union[SpatialImage, MultiscaleSpatialImage]]:
+def _get_images() -> dict[str, Union[DataArray, DataTree]]:
     out = {}
     dims_2d = ("c", "y", "x")
     dims_3d = ("z", "y", "x", "c")
@@ -244,7 +243,7 @@ def _get_images() -> dict[str, Union[SpatialImage, MultiscaleSpatialImage]]:
     return out
 
 
-def _get_labels() -> dict[str, Union[SpatialImage, MultiscaleSpatialImage]]:
+def _get_labels() -> dict[str, Union[DataArray, DataTree]]:
     out = {}
     dims_2d = ("y", "x")
     dims_3d = ("z", "y", "x")

--- a/tests/pl/test_get_extent.py
+++ b/tests/pl/test_get_extent.py
@@ -30,19 +30,19 @@ plt.tight_layout()
 
 class TestExtent(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_extent_of_img_full_canvas(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image").pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image").pl.show()
 
     def test_plot_extent_of_points_partial_canvas(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_points().pl.show()
 
     def test_plot_extent_of_partial_canvas_on_full_canvas(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image").pl.render_points().pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image").pl.render_points().pl.show()
 
     def test_plot_extent_calculation_respects_element_selection_circles(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles").pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles").pl.show()
 
     def test_plot_extent_calculation_respects_element_selection_polygons(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_polygons").pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_polygons").pl.show()
 
     def test_plot_extent_calculation_respects_element_selection_circles_and_polygons(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_shapes("blobs_circles").pl.render_shapes("blobs_polygons").pl.show()
@@ -132,12 +132,12 @@ class TestExtent(PlotTester, metaclass=PlotTesterMeta):
                 multipolygons_name = "multipolygons_pi4"
                 points_name = "points_pi4"
 
-            sdata.pl.render_shapes(elements=circles_name).pl.show(coordinate_systems=cs, ax=axs[0, cs_idx], title="")
-            sdata.pl.render_shapes(elements=polygons_name).pl.show(coordinate_systems=cs, ax=axs[1, cs_idx], title="")
-            sdata.pl.render_shapes(elements=multipolygons_name).pl.show(
+            sdata.pl.render_shapes(element=circles_name).pl.show(coordinate_systems=cs, ax=axs[0, cs_idx], title="")
+            sdata.pl.render_shapes(element=polygons_name).pl.show(coordinate_systems=cs, ax=axs[1, cs_idx], title="")
+            sdata.pl.render_shapes(element=multipolygons_name).pl.show(
                 coordinate_systems=cs, ax=axs[2, cs_idx], title=""
             )
-            sdata.pl.render_points(elements=points_name, size=10).pl.show(
+            sdata.pl.render_points(element=points_name, size=10).pl.show(
                 coordinate_systems=cs, ax=axs[3, cs_idx], title="", pad_extent=0.02
             )
 

--- a/tests/pl/test_render_images.py
+++ b/tests/pl/test_render_images.py
@@ -85,7 +85,7 @@ class TestImages(PlotTester, metaclass=PlotTesterMeta):
         ).pl.show()
 
     def test_plot_can_normalize_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(element="blobs_image", quantiles_for_norm=(5, 90)).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", percentiles_for_norm=(5, 90)).pl.show()
 
     def test_plot_can_render_multiscale_image(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_images("blobs_multiscale_image").pl.show()

--- a/tests/pl/test_render_images.py
+++ b/tests/pl/test_render_images.py
@@ -24,68 +24,68 @@ _ = spatialdata_plot
 
 class TestImages(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_render_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image").pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image").pl.show()
 
     def test_plot_can_pass_str_cmap(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", cmap="seismic").pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", cmap="seismic").pl.show()
 
     def test_plot_can_pass_cmap(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", cmap=matplotlib.colormaps["seismic"]).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", cmap=matplotlib.colormaps["seismic"]).pl.show()
 
     def test_plot_can_pass_str_cmap_list(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", cmap=["seismic", "Reds", "Blues"]).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", cmap=["seismic", "Reds", "Blues"]).pl.show()
 
     def test_plot_can_pass_cmap_list(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_images(
-            elements="blobs_image",
+            element="blobs_image",
             cmap=[matplotlib.colormaps["seismic"], matplotlib.colormaps["Reds"], matplotlib.colormaps["Blues"]],
         ).pl.show()
 
     def test_plot_can_render_a_single_channel_from_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", channel=0).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", channel=0).pl.show()
 
     def test_plot_can_render_a_single_channel_from_multiscale_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_multiscale_image", channel=0).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_multiscale_image", channel=0).pl.show()
 
     def test_plot_can_render_a_single_channel_from_image_no_el(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_images(channel=0).pl.show()
 
     def test_plot_can_render_a_single_channel_str_from_image(self, sdata_blobs_str: SpatialData):
-        sdata_blobs_str.pl.render_images(elements="blobs_image", channel="c1").pl.show()
+        sdata_blobs_str.pl.render_images(element="blobs_image", channel="c1").pl.show()
 
     def test_plot_can_render_a_single_channel_str_from_multiscale_image(self, sdata_blobs_str: SpatialData):
-        sdata_blobs_str.pl.render_images(elements="blobs_multiscale_image", channel="c1").pl.show()
+        sdata_blobs_str.pl.render_images(element="blobs_multiscale_image", channel="c1").pl.show()
 
     def test_plot_can_render_two_channels_from_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", channel=[0, 1]).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", channel=[0, 1]).pl.show()
 
     def test_plot_can_render_two_channels_from_multiscale_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_multiscale_image", channel=[0, 1]).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_multiscale_image", channel=[0, 1]).pl.show()
 
     def test_plot_can_render_two_channels_str_from_image(self, sdata_blobs_str: SpatialData):
-        sdata_blobs_str.pl.render_images(elements="blobs_image", channel=["c1", "c2"]).pl.show()
+        sdata_blobs_str.pl.render_images(element="blobs_image", channel=["c1", "c2"]).pl.show()
 
     def test_plot_can_render_two_channels_str_from_multiscale_image(self, sdata_blobs_str: SpatialData):
-        sdata_blobs_str.pl.render_images(elements="blobs_multiscale_image", channel=["c1", "c2"]).pl.show()
+        sdata_blobs_str.pl.render_images(element="blobs_multiscale_image", channel=["c1", "c2"]).pl.show()
 
     def test_plot_can_pass_color_to_single_channel(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", channel=1, palette="red").pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", channel=1, palette="red").pl.show()
 
     def test_plot_can_pass_cmap_to_single_channel(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", channel=1, cmap="Reds").pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", channel=1, cmap="Reds").pl.show()
 
     def test_plot_can_pass_color_to_each_channel(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_images(
-            elements="blobs_image", channel=[0, 1, 2], palette=["red", "green", "blue"]
+            element="blobs_image", channel=[0, 1, 2], palette=["red", "green", "blue"]
         ).pl.show()
 
     def test_plot_can_pass_cmap_to_each_channel(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_images(
-            elements="blobs_image", channel=[0, 1, 2], cmap=["Reds", "Greens", "Blues"]
+            element="blobs_image", channel=[0, 1, 2], cmap=["Reds", "Greens", "Blues"]
         ).pl.show()
 
     def test_plot_can_normalize_image(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image", quantiles_for_norm=(5, 90)).pl.show()
+        sdata_blobs.pl.render_images(element="blobs_image", quantiles_for_norm=(5, 90)).pl.show()
 
     def test_plot_can_render_multiscale_image(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_images("blobs_multiscale_image").pl.show()
@@ -115,7 +115,7 @@ class TestImages(PlotTester, metaclass=PlotTesterMeta):
 
     def test_plot_can_stack_render_images(self, sdata_blobs: SpatialData):
         (
-            sdata_blobs.pl.render_images(elements="blobs_image", channel=0, palette="red", alpha=0.5)
-            .pl.render_images(elements="blobs_image", channel=1, palette="blue", alpha=0.5)
+            sdata_blobs.pl.render_images(element="blobs_image", channel=0, palette="red", alpha=0.5)
+            .pl.render_images(element="blobs_image", channel=1, palette="blue", alpha=0.5)
             .pl.show()
         )

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -7,8 +7,7 @@ import scanpy as sc
 import spatialdata_plot  # noqa: F401
 from anndata import AnnData
 from spatial_image import to_spatial_image
-from spatialdata import SpatialData
-from spatialdata._core.query.relational_query import _get_unique_label_values_as_index
+from spatialdata import SpatialData, get_element_instances
 from spatialdata.models import TableModel
 
 from tests.conftest import DPI, PlotTester, PlotTesterMeta
@@ -29,7 +28,7 @@ _ = spatialdata_plot
 
 class TestLabels(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_render_labels(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_labels(elements="blobs_labels").pl.show()
+        sdata_blobs.pl.render_labels(element="blobs_labels").pl.show()
 
     def test_plot_can_render_multiscale_labels(self, sdata_blobs: SpatialData):
         sdata_blobs["table"].obs["region"] = "blobs_multiscale_labels"
@@ -70,10 +69,10 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_stack_render_labels(self, sdata_blobs: SpatialData):
         (
             sdata_blobs.pl.render_labels(
-                elements="blobs_labels", na_color="red", fill_alpha=1, outline_alpha=0, outline=False
+                element="blobs_labels", na_color="red", fill_alpha=1, outline_alpha=0, outline=False
             )
             .pl.render_labels(
-                elements="blobs_labels", na_color="blue", fill_alpha=0, outline_alpha=1, outline=True, contour_px=15
+                element="blobs_labels", na_color="blue", fill_alpha=0, outline_alpha=1, outline=True, contour_px=15
             )
             .pl.show()
         )
@@ -112,7 +111,7 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
         self._make_tablemodel_with_categorical_labels(sdata_blobs, label)
 
     def _make_tablemodel_with_categorical_labels(self, sdata_blobs, label):
-        n_obs = max(_get_unique_label_values_as_index(sdata_blobs[label]))
+        n_obs = max(get_element_instances(sdata_blobs[label]))
         adata = AnnData(
             RNG.normal(size=(n_obs, 10)),
             obs=pd.DataFrame(RNG.normal(size=(n_obs, 3)), columns=["a", "b", "c"]),

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -25,7 +25,7 @@ _ = spatialdata_plot
 
 class TestPoints(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_render_points(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_points(elements="blobs_points").pl.show()
+        sdata_blobs.pl.render_points(element="blobs_points").pl.show()
 
     def test_plot_can_filter_with_groups(self, sdata_blobs: SpatialData):
         sdata_blobs["table"].obs["region"] = ["blobs_points"] * sdata_blobs["table"].n_obs
@@ -53,13 +53,13 @@ class TestPoints(PlotTester, metaclass=PlotTesterMeta):
         sdata_blobs["table"].obs["region"] = ["blobs_points"] * sdata_blobs["table"].n_obs
         sdata_blobs["table"].uns["spatialdata_attrs"]["region"] = "blobs_points"
         (
-            sdata_blobs.pl.render_points(elements="blobs_points", na_color="red", size=30)
-            .pl.render_points(elements="blobs_points", na_color="blue", size=10)
+            sdata_blobs.pl.render_points(element="blobs_points", na_color="red", size=30)
+            .pl.render_points(element="blobs_points", na_color="blue", size=10)
             .pl.show()
         )
 
     def test_plot_color_recognises_actual_color_as_color(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_points(elements="blobs_points", color="red").pl.show()
+        sdata_blobs.pl.render_points(element="blobs_points", color="red").pl.show()
 
     def test_plot_points_coercable_categorical_color(self, sdata_blobs: SpatialData):
         n_obs = len(sdata_blobs["blobs_points"])

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -28,31 +28,31 @@ _ = spatialdata_plot
 
 class TestShapes(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_render_circles(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles").pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles").pl.show()
 
     def test_plot_can_render_circles_with_outline(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles", outline=True).pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles", outline=True).pl.show()
 
     def test_plot_can_render_circles_with_colored_outline(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles", outline=True, outline_color="red").pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles", outline=True, outline_color="red").pl.show()
 
     def test_plot_can_render_polygons(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_polygons").pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_polygons").pl.show()
 
     def test_plot_can_render_polygons_with_outline(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_polygons", outline=True).pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_polygons", outline=True).pl.show()
 
     def test_plot_can_render_polygons_with_str_colored_outline(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_polygons", outline=True, outline_color="red").pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_polygons", outline=True, outline_color="red").pl.show()
 
     def test_plot_can_render_polygons_with_rgb_colored_outline(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_shapes(
-            elements="blobs_polygons", outline=True, outline_color=(0.0, 0.0, 1.0, 1.0)
+            element="blobs_polygons", outline=True, outline_color=(0.0, 0.0, 1.0, 1.0)
         ).pl.show()
 
     def test_plot_can_render_polygons_with_rgba_colored_outline(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_shapes(
-            elements="blobs_polygons", outline=True, outline_color=(0.0, 1.0, 0.0, 1.0)
+            element="blobs_polygons", outline=True, outline_color=(0.0, 1.0, 0.0, 1.0)
         ).pl.show()
 
     def test_plot_can_render_empty_geometry(self, sdata_blobs: SpatialData):
@@ -60,10 +60,10 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
         sdata_blobs.pl.render_shapes().pl.show()
 
     def test_plot_can_render_circles_with_default_outline_width(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles", outline=True).pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles", outline=True).pl.show()
 
     def test_plot_can_render_circles_with_specified_outline_width(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles", outline=True, outline_width=3.0).pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles", outline=True, outline_width=3.0).pl.show()
 
     def test_plot_can_render_multipolygons(self):
         def _make_multi():
@@ -99,12 +99,12 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
         blob["table"].uns["spatialdata_attrs"]["region"] = "blobs_polygons"
         blob.shapes["blobs_polygons"]["value"] = [1, 10, 1, 20, 1]
         blob.pl.render_shapes(
-            elements="blobs_polygons",
+            element="blobs_polygons",
             color="value",
         ).pl.show()
 
     def test_plot_can_scale_shapes(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_shapes(elements="blobs_circles", scale=0.5).pl.show()
+        sdata_blobs.pl.render_shapes(element="blobs_circles", scale=0.5).pl.show()
 
     def test_plot_can_filter_with_groups(self, sdata_blobs: SpatialData):
         sdata_blobs["table"].obs["region"] = ["blobs_polygons"] * sdata_blobs["table"].n_obs
@@ -252,13 +252,13 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
 
     def test_plot_can_stack_render_shapes(self, sdata_blobs: SpatialData):
         (
-            sdata_blobs.pl.render_shapes(elements="blobs_circles", na_color="red", fill_alpha=0.5)
-            .pl.render_shapes(elements="blobs_polygons", na_color="blue", fill_alpha=0.5)
+            sdata_blobs.pl.render_shapes(element="blobs_circles", na_color="red", fill_alpha=0.5)
+            .pl.render_shapes(element="blobs_polygons", na_color="blue", fill_alpha=0.5)
             .pl.show()
         )
 
     def test_plot_color_recognises_actual_color_as_color(self, sdata_blobs: SpatialData):
-        (sdata_blobs.pl.render_shapes(elements="blobs_circles", color="red").pl.show())
+        (sdata_blobs.pl.render_shapes(element="blobs_circles", color="red").pl.show())
 
     def test_plot_shapes_coercable_categorical_color(self, sdata_blobs: SpatialData):
         n_obs = len(sdata_blobs["blobs_polygons"])

--- a/tests/pl/test_show.py
+++ b/tests/pl/test_show.py
@@ -22,4 +22,4 @@ _ = spatialdata_plot
 
 class TestShow(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_pad_extent_adds_padding(self, sdata_blobs: SpatialData):
-        sdata_blobs.pl.render_images(elements="blobs_image").pl.show(pad_extent=100)
+        sdata_blobs.pl.render_images(element="blobs_image").pl.show(pad_extent=100)

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -11,4 +11,4 @@ from spatialdata.datasets import blobs
 )
 def test_set_outline_accepts_str_or_float_or_list_thereof(outline_color):
     sdata = blobs()
-    sdata.pl.render_shapes(elements="blobs_polygons", outline=True, outline_color=outline_color).pl.show()
+    sdata.pl.render_shapes(element="blobs_polygons", outline=True, outline_color=outline_color).pl.show()


### PR DESCRIPTION
With the SpatialImage and MultiscaleSpatialImage dependency changing we need to update the repo to account for this. See [#587](https://github.com/scverse/spatialdata/pull/587).  Also the PR adjusts to some of the newest changes on the spatialdata repo such as the changes to `locate_value`

Also this PR makes some changes in order to silence warnings.

This PR requires a release of spatialdata.