### PR TITLE
migrate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ fail_fast: false
 default_language_version:
   python: python3
 default_stages:
-  - commit
-  - push
+  - pre-commit
+  - pre-push
 minimum_pre_commit_version: 2.16.0
 ci:
   skip: []


### PR DESCRIPTION
The default stages are deprecated. This PR implements changes to avoid the warning of having to migrate the config.