### PR TITLE
fix table name and add unit test for colors passed via .uns

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -755,7 +755,7 @@ def _set_color_source_vec(
         color_source_vector = pd.Categorical(color_source_vector)  # convert, e.g., `pd.Series`
 
         color_mapping = _get_categorical_color_mapping(
-            adata=sdata.table,
+            adata=sdata.tables[table_name],
             cluster_key=value_to_plot,
             color_source_vector=color_source_vector,
             groups=groups,

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -10,13 +10,15 @@ from spatial_image import to_spatial_image
 from spatialdata import SpatialData, deepcopy, get_element_instances
 from spatialdata.models import TableModel
 
+from spatialdata import bounding_box_query
+
 import spatialdata_plot  # noqa: F401
 from tests.conftest import DPI, PlotTester, PlotTesterMeta
 
 RNG = np.random.default_rng(seed=42)
 sc.pl.set_rcParams_defaults()
 sc.set_figure_params(dpi=DPI, color_map="viridis")
-matplotlib.use("agg")  # same as GitHub action runner
+#matplotlib.use("agg")  # same as GitHub action runner
 _ = spatialdata_plot
 
 # WARNING:
@@ -212,6 +214,61 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
 
     def test_plot_label_categorical_color(self, sdata_blobs: SpatialData):
         self._make_tablemodel_with_categorical_labels(sdata_blobs, labels_name="blobs_labels")
+        sdata_blobs.pl.render_labels("blobs_labels", color="category").pl.show()
+
+    def test_plot_label_categorical_color_and_colors_in_uns(self, sdata_blobs: SpatialData):
+        self._make_tablemodel_with_categorical_labels(sdata_blobs, labels_name="blobs_labels")
+         # purple, green, yellow
+        sdata_blobs[ "other_table" ].uns[ "category_colors"] = [ "#800080", "#008000", "#FFFF00" ]
+        # placeholder, otherwise "category_colors" will be ignored
+        sdata_blobs[ "other_table" ].uns[ "category" ] = "__value__"
+        sdata_blobs.pl.render_labels("blobs_labels", color="category").pl.show()
+
+    def test_plot_label_categorical_color_and_colors_in_uns_query_uns_colors_removed(self, sdata_blobs: SpatialData):
+        self._make_tablemodel_with_categorical_labels(sdata_blobs, labels_name="blobs_labels")
+         # purple, green, yellow
+        sdata_blobs[ "other_table" ].uns[ "category_colors"] = [ "#800080", "#008000", "#FFFF00" ]
+        # placeholder, otherwise "category_colors" will be ignored
+        sdata_blobs[ "other_table" ].uns[ "category" ] = "__value__"
+        sdata_blobs = bounding_box_query(
+            sdata_blobs,
+            axes=("y", "x"),
+            min_coordinate=[0, 0],
+            max_coordinate=[100, 100],
+            target_coordinate_system="global",
+        )
+         # we would expect colors purple and yellow for a and c, but we see default colors blue en orange,
+         # Reason: "category_colors" is removed by `.filter_by_coordinate_system` in
+         # `spatialdata_plot.pl.render._render_labels`.
+         # Why? Because `.bounding_box_query` removes "category_colors" that are not in the query,
+         # but restores original number of catergories in `.obs["category"]`, see https://github.com/scverse/anndata/issues/997,
+         # leading to mismatch and removal of "category_colors" by `.filter_by_coordinate_system`.
+        assert all(sdata_blobs[ "other_table" ].obs[ "category" ].unique() == [ "a", "c" ])
+        assert all(sdata_blobs[ "other_table" ].uns["category_colors" ] == [ "#800080", "#FFFF00" ])
+        # but due to https://github.com/scverse/anndata/issues/997:
+        assert all(sdata_blobs[ "other_table" ].obs["category"].cat.categories == ["a", "b", "c" ])
+        sdata_blobs.pl.render_labels("blobs_labels", color="category").pl.show()
+
+    def test_plot_label_categorical_color_and_colors_in_uns_query_workaround(self, sdata_blobs: SpatialData):
+        self._make_tablemodel_with_categorical_labels(sdata_blobs, labels_name="blobs_labels")
+         # purple, green, yellow
+        sdata_blobs[ "other_table" ].uns[ "category_colors"] = [ "#800080", "#008000", "#FFFF00" ]
+        # placeholder, otherwise "category_colors" will be ignored
+        sdata_blobs[ "other_table" ].uns[ "category" ] = "__value__"
+        sdata_blobs = bounding_box_query(
+            sdata_blobs,
+            axes=("y", "x"),
+            min_coordinate=[0, 0],
+            max_coordinate=[100, 100],
+            target_coordinate_system="global",
+        )
+        assert all(sdata_blobs[ "other_table" ].obs[ "category" ].unique() == [ "a", "c" ])
+        assert all(sdata_blobs[ "other_table" ].uns["category_colors" ] == [ "#800080", "#FFFF00" ])
+        # but due to https://github.com/scverse/anndata/issues/997:
+        assert all(sdata_blobs[ "other_table" ].obs["category"].cat.categories == ["a", "b", "c" ])
+        sdata_blobs["other_table"].obs[ "category" ]= \
+        sdata_blobs[ "other_table" ].obs[ "category" ].cat.remove_unused_categories()
+        assert all(sdata_blobs[ "other_table" ].obs["category"].cat.categories == ["a", "c" ])
         sdata_blobs.pl.render_labels("blobs_labels", color="category").pl.show()
 
     def _make_tablemodel_with_categorical_labels(self, sdata_blobs, labels_name: str):


### PR DESCRIPTION
`spatialdata_plot.pl.render._render_labels`  still had `sdata.table` , changed to `sdata.tables[table_name]`, otherwise colors passed via .uns where ignored.

also in https://github.com/scverse/spatialdata-plot/blob/43f25f654e123ca3a6a5da0e499ef15f22d0ec27/src/spatialdata_plot/pl/utils.py#L854

I would remove the check `cluster_key` in `adata.uns`. Because of this I had to set

        `sdata_blobs[ "other_table" ].uns[ "category" ] = "__value__"`

as a placeholder in https://github.com/ArneDefauw/spatialdata-plot/blob/b5cb0260c32a859783f87f10b8af05dc26feab76/tests/pl/test_render_labels.py#L219 . 

I also stumbled upon a subtle bug while testing this feature. With the small fix in this PR, one can pass colors via .uns[ f"{cluster_key}_colors" ], and all works as expected, see 
https://github.com/ArneDefauw/spatialdata-plot/blob/b5cb0260c32a859783f87f10b8af05dc26feab76/tests/pl/test_render_labels.py#L219

We get:
![no_query](https://github.com/user-attachments/assets/626b942c-9713-428b-be97-c13335cd97b1)

But if we do a bounding box query, we get:
![query_fail](https://github.com/user-attachments/assets/a4c8c2a5-1039-47d6-94ac-c2ba61a7d695)

While we expect:
![Figure_1](https://github.com/user-attachments/assets/b576b5a7-5151-433b-bbad-431069827c87)

In short, this is caused by https://github.com/scverse/spatialdata/blob/03d3be80fad69ff54097e90a9e80ad02e9e0e242/src/spatialdata/_utils.py#L203 

also see  https://github.com/scverse/anndata/issues/997 

For details see https://github.com/ArneDefauw/spatialdata-plot/blob/b5cb0260c32a859783f87f10b8af05dc26feab76/tests/pl/test_render_labels.py#L227 and possible workaround https://github.com/ArneDefauw/spatialdata-plot/blob/b5cb0260c32a859783f87f10b8af05dc26feab76/tests/pl/test_render_labels.py#L252

Note that being able to plot a subset in the same colors as the orignal is a rather common use case. However, I am not sure where to fix. Maybe documenting the workaround suffices for now.

