### PR TITLE
Generating and saving view configs from tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.5.1
     hooks:
       - id: prettier
   - repo: https://github.com/asottile/blacken-docs

--- a/src/spatialdata_plot/config.py
+++ b/src/spatialdata_plot/config.py
@@ -1,0 +1,2 @@
+# default value for the parameter store_viewconfig_in_attrs for .pl.show()
+STORE_VIEWCONFIG_IN_ATTRS = False

--- a/src/spatialdata_plot/pl/_viewconfig.py
+++ b/src/spatialdata_plot/pl/_viewconfig.py
@@ -1,19 +1,29 @@
-from pathlib import Path
-import spatialdata
-from uuid import uuid4, UUID
+from __future__ import annotations
+
+from collections import OrderedDict
 from enum import Enum
-from matplotlib.figure import Figure
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
 import matplotlib.colors as mcolors
+import spatialdata
 from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
 from spatialdata_plot.pl.render_params import (
+    FigParams,
     ImageRenderParams,
     LabelsRenderParams,
     PointsRenderParams,
     ShapesRenderParams,
 )
-from typing import OrderedDict
 
 Params = ImageRenderParams | LabelsRenderParams | PointsRenderParams | ShapesRenderParams
+
+if TYPE_CHECKING:
+    from spatialdata import SpatialData
+
 
 class VegaAlignment(Enum):
     LEFT = "start"
@@ -21,16 +31,13 @@ class VegaAlignment(Enum):
     RIGHT = "end"
 
     @classmethod
-    def from_matplotlib(cls, alignment: str):
+    def from_matplotlib(cls, alignment: str) -> str:
         """Convert Matplotlib horizontal alignment to Vega alignment."""
-        mapping = {
-            "left": cls.LEFT,
-            "center": cls.CENTER,
-            "right": cls.RIGHT
-        }
+        mapping = {"left": cls.LEFT, "center": cls.CENTER, "right": cls.RIGHT}
         return mapping.get(alignment, cls.CENTER).value
 
-def _create_axis_scale_block(ax: Axes):
+
+def _create_axis_scale_block(ax: Axes) -> list[dict[str, Any]]:
     """Create vega scales object pertaining to both the x and the y axis.
 
     Parameters
@@ -44,7 +51,7 @@ def _create_axis_scale_block(ax: Axes):
     return scales
 
 
-def _get_axis_scale_config(ax: Axes, axis_name: str):
+def _get_axis_scale_config(ax: Axes, axis_name: str) -> dict[str, Any]:
     """Provide a vega like scales object particular for one of the plotting axes.
 
     Note that in vega, this config also contains the fields reverse and zero.
@@ -57,20 +64,20 @@ def _get_axis_scale_config(ax: Axes, axis_name: str):
     axis_name: str
         Which axis the config should be made for, either "x" or "y".
     """
-    scale = {}
+    scale: dict[str, Any] = {}
     scale["name"] = f"{axis_name.upper()}_scale"
     if axis_name == "x":
         scale["type"] = ax.get_xaxis().get_scale()
-        scale["domain"] = [ax.get_xlim()[0], ax.get_xlim()[1]]
+        scale["domain"] = [ax.get_xlim()[0].item(), ax.get_xlim()[1].item()]
         scale["range"] = "width"
     if axis_name == "y":
         scale["type"] = ax.get_yaxis().get_scale()
-        scale["domain"] = [ax.get_ylim()[0], ax.get_ylim()[1]]
+        scale["domain"] = [ax.get_ylim()[0].item(), ax.get_ylim()[1].item()]
         scale["range"] = "height"
     return scale
 
 
-def _create_padding_object(fig: Figure):
+def _create_padding_object(fig: Figure) -> dict[str, float]:
     """Get the padding parameters for a vega viewconfiguration.
 
     Given that matplotlib gives the padding parameters as a fraction of the the figure width or height and
@@ -84,15 +91,15 @@ def _create_padding_object(fig: Figure):
     fig_width_pixels, fig_height_pixels = fig.get_size_inches() * fig.dpi
     # contains also wspace and hspace but does not seem to be used by vega here.
     padding_obj = fig.subplotpars
-    padding = {
-        "left": padding_obj.left * fig_width_pixels,
-        "top": (1 - padding_obj.top) * fig_height_pixels,
-        "right": (1 - padding_obj.right) * fig_width_pixels,
-        "bottom": padding_obj.bottom * fig_height_pixels,
+    return {
+        "left": (padding_obj.left * fig_width_pixels).item(),
+        "top": ((1 - padding_obj.top) * fig_height_pixels).item(),
+        "right": ((1 - padding_obj.right) * fig_width_pixels).item(),
+        "bottom": (padding_obj.bottom * fig_height_pixels).item(),
     }
-    return padding
 
-def _create_base_level_sdata_block(url: Path):
+
+def _create_base_level_sdata_block(url: str) -> dict[str, Any]:
     """Create the vega json object for the SpatialData zarr store.
 
     Parameters
@@ -102,14 +109,14 @@ def _create_base_level_sdata_block(url: Path):
 
     This config is to be added to the vega data field block.
     """
-    base_block = {}
-    base_block["name"] = uuid4()
-    base_block["url"] = str(url)
-    base_block["format"] = {"type": "SpatialData",
-                            "version": spatialdata.__version__}
-    return base_block
+    return {
+        "name": str(uuid4()),
+        "url": url,
+        "format": {"type": "SpatialData", "version": spatialdata.__version__},
+    }
 
-def _create_derived_data_block(call: str, params: Params, base_uuid: UUID, cs: str):
+
+def _create_derived_data_block(call: str, params: Params, base_uuid: str, cs: str) -> dict[str, Any]:
     """Create vega like data object for SpatialData elements.
 
     Each object for a SpatialData element contains an additional transform that
@@ -124,15 +131,15 @@ def _create_derived_data_block(call: str, params: Params, base_uuid: UUID, cs: s
     params: Params
         The render parameters used in spatialdata-plot for the particular type of SpatialData
         element.
-    base_uuid: UUID
+    base_uuid: str
         Unique identifier used to refer to the base level SpatialData zarr store in the vega
         like view configuration.
     cs: str
         The name of the coordinate system in which the SpatialData element was plotted.
     """
-    data_block = {}
+    data_block: dict[str, Any] = {}
 
-    data_block["name"] = uuid4()
+    data_block["name"] = str(uuid4())
     # TODO: think about versioning of individual spatialdata elements
     if "render_images" in call:
         data_block["format"] = {"type": "spatialdata_image", "version": 0.1}
@@ -146,12 +153,11 @@ def _create_derived_data_block(call: str, params: Params, base_uuid: UUID, cs: s
         raise ValueError(f"Unknown call: {call}")
 
     data_block["source"] = base_uuid
-    data_block["transform"] = [{"type": "filter_element", "expr": params.element},
-                               {"type": "filter_cs", "expr": cs}]
+    data_block["transform"] = [{"type": "filter_element", "expr": params.element}, {"type": "filter_cs", "expr": cs}]
     return data_block
 
 
-def _create_data_configs(plotting_tree: OrderedDict[str, Params], cs: str, sdata_path: str):
+def _create_data_configs(plotting_tree: OrderedDict[str, Params], cs: str, sdata_path: str) -> list[dict[str, Any]]:
     """Create the vega json array value to the data key.
 
     The data array in the SpatialData vegalike viewconfig consists out of
@@ -170,7 +176,7 @@ def _create_data_configs(plotting_tree: OrderedDict[str, Params], cs: str, sdata
         The location of the SpatialData zarr store.
     """
     data = []
-    url = Path("sdata.zarr")
+    url = str(Path("sdata.zarr"))
 
     if sdata_path:
         url = sdata_path
@@ -183,7 +189,7 @@ def _create_data_configs(plotting_tree: OrderedDict[str, Params], cs: str, sdata
     return data
 
 
-def _create_title_config(ax, fig):
+def _create_title_config(ax: Axes, fig: Figure) -> dict[str, Any]:
     """Create a vega title object for a spatialdata view configuration.
 
     Note that not all field values as obtained from matplotlib are supported by the official
@@ -200,19 +206,20 @@ def _create_title_config(ax, fig):
     title_obj = ax.title
     title_font = title_obj.get_fontproperties()
 
-    title_config = {"text": title_text,
-                    "orient": "top", # there is not really a nice conversion here of matplotlib to vega
-                    "anchor": VegaAlignment.from_matplotlib(title_obj.get_horizontalalignment()),
-                    "baseline": title_obj.get_va(),
-                    "color": title_obj.get_color(),
-                    "font": title_obj.get_fontname(),
-                    "fontSize": (title_font.get_size() * fig.dpi) / 72,
-                    "fontStyle": title_obj.get_fontstyle(),
-                    "fontWeight": title_font.get_weight(),
-                    }
-    return title_config
+    return {
+        "text": title_text,
+        "orient": "top",  # there is not really a nice conversion here of matplotlib to vega
+        "anchor": VegaAlignment.from_matplotlib(title_obj.get_horizontalalignment()),
+        "baseline": title_obj.get_va(),
+        "color": title_obj.get_color(),
+        "font": title_obj.get_fontname(),
+        "fontSize": (title_font.get_size() * fig.dpi) / 72,
+        "fontStyle": title_obj.get_fontstyle(),
+        "fontWeight": title_font.get_weight(),
+    }
 
-def _create_axis_block(ax, axis_scales_block, dpi):
+
+def _create_axis_block(ax: Axes, axis_scales_block: list[dict[str, Any]], dpi: float) -> list[dict[str, Any]]:
     axis_array = []
     for scale in axis_scales_block:
         axis_config = {}
@@ -227,7 +234,7 @@ def _create_axis_block(ax, axis_scales_block, dpi):
         axis_config["orient"] = axis.get_label_position()
 
         axis_line_props = ax.spines[axis_config["orient"]].properties()
-        axis_config["domain"] = axis_line_props['visible'] # domain is whether axis line should be visible.
+        axis_config["domain"] = axis_line_props["visible"]  # domain is whether axis line should be visible.
         axis_config["domainOpacity"] = axis_line_props["alpha"] if axis_line_props["alpha"] else 1
         axis_config["domainColor"] = mcolors.to_hex(axis_line_props["edgecolor"])[:-2]
         axis_config["domainWidth"] = (axis_line_props["linewidth"] * dpi) / 72
@@ -235,15 +242,15 @@ def _create_axis_block(ax, axis_scales_block, dpi):
 
         # making the assumption here that all gridlines look the same
         if axis_config["grid"]:
-            axis_config["gridOpacity"] = axis_props["gridlines"][0].properties()['alpha']
-            axis_config["gridCap"] = axis_props["gridlines"][0].properties()['dash_capstyle']
-            grid_color = float(axis_props["gridlines"][0].properties()['markeredgecolor'])
-            axis_config["gridColor"] = mcolors.to_hex([grid_color]*3)
+            axis_config["gridOpacity"] = axis_props["gridlines"][0].properties()["alpha"]
+            axis_config["gridCap"] = axis_props["gridlines"][0].properties()["dash_capstyle"]
+            grid_color = float(axis_props["gridlines"][0].properties()["markeredgecolor"])
+            axis_config["gridColor"] = mcolors.to_hex([grid_color] * 3)
             axis_config["gridWidth"] = (axis_props["gridlines"][0].properties()["markeredgewidth"] * dpi) / 72
-        axis_config["labelFont"] = axis_props['majorticklabels'][0].get_fontname()
-        axis_config["labelFontSize"] = (axis_props['majorticklabels'][0].get_size() * dpi) / 72
-        axis_config["labelFontStyle"] = axis_props['majorticklabels'][0].get_fontstyle()
-        axis_config["labelFontWeight"] = axis_props['majorticklabels'][0].get_fontweight()
+        axis_config["labelFont"] = axis_props["majorticklabels"][0].get_fontname()
+        axis_config["labelFontSize"] = (axis_props["majorticklabels"][0].get_size() * dpi) / 72
+        axis_config["labelFontStyle"] = axis_props["majorticklabels"][0].get_fontstyle()
+        axis_config["labelFontWeight"] = axis_props["majorticklabels"][0].get_fontweight()
         axis_config["tickCount"] = len(axis_props["ticklocs"])
         if axis_config["tickCount"] != 0:
             tick_props = axis_props["ticklines"][0].properties()
@@ -252,8 +259,10 @@ def _create_axis_block(ax, axis_scales_block, dpi):
             if axis_config["ticks"] and axis_config["tickOpacity"] != 0:
                 axis_config["tickColor"] = mcolors.to_hex(tick_props["color"])
                 axis_config["tickCap"] = tick_props["dash_capstyle"]
-                axis_config["tickWidth"] = (tick_props['linewidth'] * dpi) / 72
-                axis_config["tickSize"] = (tick_props['markersize'] * dpi) / 72 #also marker edge width, but vega doesn't have an equivalent for that.
+                axis_config["tickWidth"] = (tick_props["linewidth"] * dpi) / 72
+                axis_config["tickSize"] = (
+                    tick_props["markersize"] * dpi
+                ) / 72  # also marker edge width, but vega doesn't have an equivalent for that.
 
         label = axis_props["label_text"]
         if label == "":
@@ -272,7 +281,8 @@ def _create_axis_block(ax, axis_scales_block, dpi):
         axis_array.append(axis_config)
     return axis_array
 
-def create_viewconfig(sdata, fig_params, legend_params, cs):
+
+def create_viewconfig(sdata: SpatialData, fig_params: FigParams, legend_params: Any, cs: str) -> dict[str, Any]:
     fig = fig_params.fig
     ax = fig_params.ax
     data_block = _create_data_configs(sdata.plotting_tree, cs, sdata._path)
@@ -280,15 +290,13 @@ def create_viewconfig(sdata, fig_params, legend_params, cs):
     axis_scales_block = _create_axis_scale_block(ax)
     axis_array = _create_axis_block(ax, axis_scales_block, fig.dpi)
 
-    viewconfig = {
+    return {
         "$schema": "https://spatialdata-plot.github.io/schema/viewconfig/v1.json",
-        "height": fig.get_figheight() * fig.dpi, # matplotlib uses inches, but vega uses absolute pixels
+        "height": fig.get_figheight() * fig.dpi,  # matplotlib uses inches, but vega uses absolute pixels
         "width": fig.get_figwidth() * fig.dpi,
         "padding": _create_padding_object(fig),
         "title": _create_title_config(ax, fig),
         "data": data_block,
         "scales": axis_scales_block,
         "axes": axis_array,
-
     }
-    print()

--- a/tests/pl/test_get_extent.py
+++ b/tests/pl/test_get_extent.py
@@ -51,9 +51,10 @@ class TestExtent(PlotTester, metaclass=PlotTesterMeta):
         cropped_blobs = sdata_blobs.query.bounding_box(
             axes=["x", "y"], min_coordinate=[100, 100], max_coordinate=[400, 400], target_coordinate_system="global"
         )
+        cropped_blobs._sdata = sdata_blobs
         cropped_blobs.pl.render_images().pl.show()
 
-    def test_plot_correct_plot_after_transformations(self):
+    def test_plot_correct_plot_after_transformations(self, sdata_empty):
         # inspired by https://github.com/scverse/spatialdata/blob/ef0a2dc7f9af8d4c84f15eec503177f1d08c3d46/tests/core/test_data_extent.py#L125
 
         circles = [Point(p) for p in [[0.5, 0.1], [0.9, 0.5], [0.5, 0.9], [0.1, 0.5]]]
@@ -98,6 +99,7 @@ class TestExtent(PlotTester, metaclass=PlotTesterMeta):
             },
             points={"points": points_df, "points_pi3": points_df, "points_pi4": points_df},
         )
+        sdata._sdata = sdata_empty
 
         for i in [3, 4]:
             theta = math.pi / i

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -120,6 +120,9 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
             sdata_blobs.pl.render_labels(label, color="channel_1_sum", table="other_table", scale="scale0").pl.show(
                 ax=axs[0], title="ch_1_sum", colorbar=False
             )
+            sdata_blobs.pl.render_labels(label, color="channel_1_sum", table="other_table", scale="scale0").pl.show(
+                ax=axs[0], title="ch_1_sum", colorbar=False
+            )
             sdata_blobs.pl.render_labels(label, color="channel_2_sum", table="other_table", scale="scale0").pl.show(
                 ax=axs[1], title="ch_2_sum", colorbar=False
             )
@@ -130,6 +133,7 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
         # we're modifying the data here, so we need an independent copy
         sdata_blobs_local = deepcopy(sdata_blobs)
 
+        sdata_blobs_local._sdata = sdata_blobs
         _make_tablemodel_with_categorical_labels(sdata_blobs_local, label)
 
     def test_plot_two_calls_with_coloring_result_in_two_colorbars(self, sdata_blobs: SpatialData):
@@ -141,6 +145,7 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
         table.uns["spatialdata_attrs"]["region"] = "blobs_multiscale_labels"
         table = table[:, ~table.var_names.isin(["channel_0_sum"])]
         sdata_blobs_local["multi_table"] = table
+        sdata_blobs_local._sdata = sdata_blobs
         sdata_blobs_local.pl.render_labels("blobs_labels", color="channel_0_sum", table_name="table").pl.render_labels(
             "blobs_multiscale_labels", color="channel_1_sum", table_name="multi_table"
         ).pl.show()

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -166,6 +166,7 @@ class TestPoints(PlotTester, metaclass=PlotTesterMeta):
         temp.loc[195, "y"] = 159
         temp.loc[195, "instance_id"] = 13
         blob["blobs_points"] = PointsModel.parse(dask.dataframe.from_pandas(temp, 1), coordinates={"x": "x", "y": "y"})
+        blob._sdata = sdata_blobs
         blob.pl.render_points(
             element="blobs_points", size=40, color="instance_id", method="datashader", datashader_reduction="std"
         ).pl.show()
@@ -190,7 +191,7 @@ class TestPoints(PlotTester, metaclass=PlotTesterMeta):
             element="blobs_points", size=400, color="yellow", method="datashader", alpha=0.8
         ).pl.show(dpi=200)
 
-    def test_plot_points_transformed_ds_agrees_with_mpl(self):
+    def test_plot_points_transformed_ds_agrees_with_mpl(self, sdata_empty):
         sdata = SpatialData(
             points={
                 "points1": PointsModel.parse(
@@ -199,6 +200,7 @@ class TestPoints(PlotTester, metaclass=PlotTesterMeta):
                 )
             },
         )
+        sdata._sdata = sdata_empty
         sdata.pl.render_points("points1", method="matplotlib", size=50, color="lightgrey").pl.render_points(
             "points1", method="datashader", size=10, color="red"
         ).pl.show()

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -71,7 +71,7 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_render_circles_with_specified_outline_width(self, sdata_blobs: SpatialData):
         sdata_blobs.pl.render_shapes(element="blobs_circles", outline_alpha=1, outline_width=3.0).pl.show()
 
-    def test_plot_can_render_multipolygons(self):
+    def test_plot_can_render_multipolygons(self, sdata_empty):
         def _make_multi():
             hole = MultiPolygon(
                 [(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)), [((0.2, 0.2), (0.2, 0.8), (0.8, 0.8), (0.8, 0.2))])]
@@ -92,6 +92,7 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
             return sd_polygons
 
         sdata = SpatialData(shapes={"p": _make_multi()})
+        sdata._sdata = sdata_empty
         adata = anndata.AnnData(pd.DataFrame({"p": ["hole", "overlap", "square", "circle"]}))
         adata.obs.loc[:, "region"] = "p"
         adata.obs.loc[:, "val"] = [0, 1, 2, 3]
@@ -104,6 +105,7 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
         blob["table"].obs["region"] = "blobs_polygons"
         blob["table"].uns["spatialdata_attrs"]["region"] = "blobs_polygons"
         blob.shapes["blobs_polygons"]["value"] = [1, 10, 1, 20, 1]
+        blob._sdata = sdata_blobs
         blob.pl.render_shapes(
             element="blobs_polygons",
             color="value",
@@ -166,6 +168,7 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
         cropped_blob = blob.query.bounding_box(
             axes=["x", "y"], min_coordinate=[100, 100], max_coordinate=[300, 300], target_coordinate_system="global"
         )
+        cropped_blob._sdata = sdata_blobs
         cropped_blob.pl.render_shapes().pl.show()
 
     def test_plot_can_plot_with_annotation_despite_random_shuffling(self, sdata_blobs: SpatialData):
@@ -213,6 +216,7 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
             filter_table=True,
         )
 
+        sdata_cropped._sdata = sdata_blobs
         sdata_cropped.pl.render_shapes("blobs_circles", color="annotation").pl.show()
 
     def test_plot_can_color_two_shapes_elements_by_annotation(self, sdata_blobs: SpatialData):
@@ -257,6 +261,7 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
             filter_table=True,
         )
 
+        sdata_cropped._sdata = sdata_blobs
         sdata_cropped.pl.render_shapes("blobs_circles", color="annotation").pl.render_shapes(
             "blobs_polygons", color="annotation"
         ).pl.show()


### PR DESCRIPTION
During the Basel hackathon, @melonora @keller-mark @Sonja-Stockhaus and I, started working on view configurations to streamline the plotting experience. Specifically @melonora is working on functions to generate some preliminary view configuration from the `spatialdata-plot` plotting tree. This work is available in the branch `viewconfig`. 

This PR (ready to merge, since it's opened against the [`viewconfig`](https://github.com/scverse/spatialdata-plot/tree/viewconfig) branch), modifies the test configuration to automatically generate the view configurations for each test plot and save them in `tests/figures_viewconfig`. To view such view configurations please run the tests (I haven't included the view configurations in this PR since they are still very work-in-progress).

In the screenshot you can have a sneak peek.
<img width="1318" alt="image" src="https://github.com/user-attachments/assets/8879f984-b204-4af1-8944-7e2b8a973f35" />