### PR TITLE
Fix unused cmap in render_points

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -523,6 +523,7 @@ def _render_points(
         palette=palette,
         na_color=default_color,
         cmap_params=render_params.cmap_params,
+        alpha=render_params.alpha,
         table_name=table_name,
     )
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -525,6 +525,7 @@ def _render_points(
         cmap_params=render_params.cmap_params,
         alpha=render_params.alpha,
         table_name=table_name,
+        render_type="points",
     )
 
     # color_source_vector is None when the values aren't categorical

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -714,6 +714,7 @@ def _set_color_source_vec(
     alpha: float = 1.0,
     table_name: str | None = None,
     table_layer: str | None = None,
+    render_type: Literal["points"] | None = None,
 ) -> tuple[ArrayLike | pd.Series | None, ArrayLike, bool]:
     if value_to_plot is None and element is not None:
         color = np.full(len(element), na_color)
@@ -763,6 +764,7 @@ def _set_color_source_vec(
             groups=groups,
             palette=palette,
             na_color=na_color,
+            render_type=render_type,
         )
 
         color_source_vector = color_source_vector.set_categories(color_mapping.keys())
@@ -919,6 +921,7 @@ def _get_categorical_color_mapping(
     alpha: float = 1,
     groups: list[str] | str | None = None,
     palette: list[str] | str | None = None,
+    render_type: Literal["points"] | None = None,
 ) -> Mapping[str, str]:
     if not isinstance(color_source_vector, Categorical):
         raise TypeError(f"Expected `categories` to be a `Categorical`, but got {type(color_source_vector).__name__}")
@@ -926,7 +929,7 @@ def _get_categorical_color_mapping(
     if isinstance(groups, str):
         groups = [groups]
 
-    if not palette:
+    if not palette and render_type == "points":
         if cmap_params is not None and not cmap_params.cmap_is_default:
             palette = cmap_params.cmap
         color_idx = color_idx = np.linspace(0, 1, len(color_source_vector.categories))

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -929,9 +929,9 @@ def _get_categorical_color_mapping(
     if isinstance(groups, str):
         groups = [groups]
 
-    if not palette and render_type == "points":
-        if cmap_params is not None and not cmap_params.cmap_is_default:
-            palette = cmap_params.cmap
+    if not palette and render_type == "points" and cmap_params is not None and not cmap_params.cmap_is_default:
+        palette = cmap_params.cmap
+
         color_idx = color_idx = np.linspace(0, 1, len(color_source_vector.categories))
         if isinstance(palette, ListedColormap):
             palette = [to_hex(x) for x in palette(color_idx, alpha=alpha)]

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -84,9 +84,9 @@ class TestLabels(PlotTester, metaclass=PlotTesterMeta):
         sdata_blobs.pl.render_labels("blobs_labels", color="channel_0_sum").pl.show()
 
     def test_plot_can_color_labels_by_categorical_variable(self, sdata_blobs: SpatialData):
-        max_col = sdata_blobs.table.to_df().idxmax(axis=1)
-        max_col = pd.Categorical(max_col, categories=sdata_blobs.table.to_df().columns, ordered=True)
-        sdata_blobs.table.obs["which_max"] = max_col
+        max_col = sdata_blobs["table"].to_df().idxmax(axis=1)
+        max_col = pd.Categorical(max_col, categories=sdata_blobs["table"].to_df().columns, ordered=True)
+        sdata_blobs["table"].obs["which_max"] = max_col
 
         sdata_blobs.pl.render_labels("blobs_labels", color="which_max").pl.show()
 


### PR DESCRIPTION
The test `test_plot_coloring_with_cmap` in the tests for points was wrongly passing. When switching from the use of `get_categorical_obs` to `_get_categorical_color_mapping`, the `cmap` was not anymore in the arguments. This led to the default colors always being used despite a colormap being defined. This PR fixes that issue by updating `_get_categorical_color_mapping`.
On main:
![image](https://github.com/user-attachments/assets/5f311fc7-3322-4494-8e4a-6c2e69e37bbe)

With this PR:
![image](https://github.com/user-attachments/assets/9d90c1d5-6175-4528-bcd2-78cb0c56f5ae)
