### PR TITLE
Get one shape transform

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -185,7 +185,7 @@ def _render_shapes(
             sdata_filt.shapes[element].loc[is_point, "geometry"] = _geometry[is_point].buffer(scale.to_numpy())
 
         # apply transformations to the individual points
-        element_trans = get_transformation(sdata_filt.shapes[element])
+        element_trans = get_transformation(sdata_filt.shapes[element], to_coordinate_system=coordinate_system)
         tm = _get_transformation_matrix_for_datashader(element_trans)
         transformed_element = sdata_filt.shapes[element].transform(
             lambda x: (np.hstack([x, np.ones((x.shape[0], 1))]) @ tm)[:, :2]
@@ -195,7 +195,7 @@ def _render_shapes(
         )
 
         plot_width, plot_height, x_ext, y_ext, factor = _get_extent_and_range_for_datashader_canvas(
-            transformed_element, coordinate_system, ax, fig_params
+            transformed_element, "global", ax, fig_params
         )
 
         cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, x_range=x_ext, y_range=y_ext)


### PR DESCRIPTION
closes: #447 

In render shapes, when using datashader, all transforms were obtained instead of the transform to the coordinate system which is supposed to be rendered. This was a problem for the visium notebook when trying the following code snippet:

```
import spatialdata as sd
import spatialdata_plot  
import matplotlib.pyplot as plt

sdata = sd.read_zarr("C:\\Users\\w-mv\\PycharmProjects\\spatialdata-notebooks\\notebooks\\examples\\visium_hd.zarr")

plt.figure(figsize=(10, 10))
ax = plt.gca()

gene_name = "AA986860"
sdata.pl.render_shapes("Visium_HD_Mouse_Small_Intestine_square_016um", color=gene_name, method="datashader").pl.show(
    coordinate_systems="Visium_HD_Mouse_Small_Intestine", ax=ax
)
```

After fixing that, the transform was applied and again parsed by `ShapesModel`. This ensured that after that one can only have a `shape` with coordinate system `global`. This means that the following should always use coordinate system `global`:
```
plot_width, plot_height, x_ext, y_ext, factor = _get_extent_and_range_for_datashader_canvas(
            transformed_element, "global", ax, fig_params
        )
```        