### PR TITLE
fix #464

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -136,7 +136,7 @@ def _render_shapes(
     if isinstance(groups, list) and color_source_vector is not None:
         mask = color_source_vector.isin(groups)
         shapes = shapes[mask]
-        shapes = shapes.reset_index()
+        shapes = shapes.reset_index(drop=True)
         color_source_vector = color_source_vector[mask]
         color_vector = color_vector[mask]
 


### PR DESCRIPTION
Code which previously failed now generates the expected results:

```
import spatialdata
import spatialdata_plot
sdata = spatialdata.datasets.blobs()

# add some labelling we want to color with a custom defined palette
sdata["table"].obs["labelling"] = (sdata["table"].obs["instance_id"]>10).astype('int').astype('str')
sdata["table"].obs["labelling"] = sdata["table"].obs["labelling"].astype('category')

# with labels it works
sdata.pl.render_labels("blobs_labels", color = "labelling", palette = ["red", "blue"], groups = ["0", "1"]).pl.show()
# transform to shapes and add necessary annotation
sdata["test_labels"] = spatialdata.to_polygons(sdata["blobs_labels"])

adata = sdata["table"].copy()
adata.obs["region"] = "test_labels"
adata.uns["spatialdata_attrs"]["region"] = "test_labels"
sdata["test_annotation"] = spatialdata.models.TableModel.parse(adata)

# with shapes it throws an error
sdata.pl.render_shapes("test_labels", color = "labelling", palette = ["red", "blue"], groups = ["0", "1"]).pl.show()
```

![image](https://github.com/user-attachments/assets/c788b051-fee8-46f2-814a-241480762abc)


