### PR TITLE
make outline behavior more similar to squidpy

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -161,8 +161,8 @@ class PlotAccessor:
         groups: list[str] | str | None = None,
         palette: list[str] | str | None = None,
         na_color: ColorLike | None = "default",
-        outline_width: float | int = 1.5,
-        outline_color: str | list[float] = "#000000",
+        outline_width: float | int | tuple[float | int, float | int] = 1.5,
+        outline_color: str | list[float] | tuple[str | list[float], str | list[float]] = "#000000",
         outline_alpha: float | int = 0.0,
         cmap: Colormap | str | None = None,
         norm: Normalize | None = None,
@@ -207,13 +207,15 @@ class PlotAccessor:
             Color to be used for NAs values, if present. Can either be a named color ("red"), a hex representation
             ("#000000ff") or a list of floats that represent RGB/RGBA values (1.0, 0.0, 0.0, 1.0). When None, the values
             won't be shown.
-        outline_width : float | int, default 1.5
-            Width of the border.
+        outline_width : float | int | tuple[float | int, float | int], default 1.5
+            Width of the border. If 2 values are given (tuple), 2 borders are shown with these widths (outer & inner).
+            In that case, and if < 2 outline_colors are specified, the default color (`outline_color`, "white") is used.
         outline_color : str | list[float], default "#000000"
             Color of the border. Can either be a named color ("red"), a hex representation ("#000000") or a list of
             floats that represent RGB/RGBA values (1.0, 0.0, 0.0, 1.0). If the hex representation includes alpha, e.g.
             "#000000ff", the last two positions are ignored, since the alpha of the outlines is solely controlled by
-            `outline_alpha`.
+            `outline_alpha`. If 2 values are given (tuple), 2 borders are shown with these colors (outer & inner).
+            In that case, and if < 2 outline widths are specified, the default width (`outline_width`, 0.5) is used.
         outline_alpha : float | int, default 0.0
             Alpha value for the outline of shapes. Invisible by default.
         cmap : Colormap | str | None, optional
@@ -247,6 +249,8 @@ class PlotAccessor:
         - Empty geometries will be removed at the time of plotting.
         - An `outline_width` of 0.0 leads to no border being plotted.
         - When passing a color-like to 'color', this has precendence over the potential existence as a column name.
+        - If a double outline is rendered, the alpha of the inner and outer border cannot be set individually. The value
+          of `outline_alpha` is always applied to both.
 
         Returns
         -------

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -350,6 +350,26 @@ def _render_shapes(
             )
 
     elif method == "matplotlib":
+        # render outlines separately to ensure they are always underneath the shape
+        if render_params.outline_alpha > 0:
+            _cax = _get_collection_shape(
+                shapes=shapes,
+                s=render_params.scale,
+                c=np.array([render_params.outline_params.outline_color]),
+                render_params=render_params,
+                rasterized=sc_settings._vector_friendly,
+                cmap=None,
+                norm=None,
+                fill_alpha=0.0,
+                outline_alpha=render_params.outline_alpha,
+                zorder=render_params.zorder,
+                # **kwargs,
+            )
+            cax = ax.add_collection(_cax)
+            # Transform the paths in PatchCollection
+            for path in _cax.get_paths():
+                path.vertices = trans.transform(path.vertices)
+
         _cax = _get_collection_shape(
             shapes=shapes,
             s=render_params.scale,
@@ -359,7 +379,7 @@ def _render_shapes(
             cmap=render_params.cmap_params.cmap,
             norm=norm,
             fill_alpha=render_params.fill_alpha,
-            outline_alpha=render_params.outline_alpha,
+            outline_alpha=0.0,
             zorder=render_params.zorder,
             # **kwargs,
         )

--- a/src/spatialdata_plot/pl/render_params.py
+++ b/src/spatialdata_plot/pl/render_params.py
@@ -48,6 +48,9 @@ class OutlineParams:
     outline: bool
     outline_color: str | list[float]
     linewidth: float
+    inner_outline: bool = False
+    inner_outline_color: str | list[float] = "#FFFFFF"
+    inner_outline_linewidth: float = 0.5
 
 
 @dataclass


### PR DESCRIPTION
For outsourcing the plotting from squidpy to spatialdata-plot: refactor the outlines of the shapes to be more similar to squidpy. This includes:
1) outlines always lie behind the shapes (both are rendered separately with the shapes on top of the outlines). Note: since the usual behavior of mpl and ds is to draw the line so that half of it lies "within" and the other half outside the shape, the outlines will shine through for instance if alpha_fill < 1.0!
2) enabling a double outline. Now, the arguments `outline_width` and `outline_color` take either a single argument as before, or a tuple of two values referring to the outer and inner outline. If one of the two arguments indicates that 2 outlines should be drawn but the other is not used (or only contains of 1 value which would be interpreted as referring to the outer outline), the missing value(s) are set to the defaults which are for the outer outline: 1.5 and "black" and for the inner outline: 0.5 and "white". If the linewidth for the inner outline is wider than the one of the outer outline, it will hide the outer outline (if alpha = 1.0).