### PR TITLE
add `shapes` parameter to render shapes as hex/circle/square

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -5,7 +5,7 @@ import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -170,6 +170,7 @@ class PlotAccessor:
         method: str | None = None,
         table_name: str | None = None,
         table_layer: str | None = None,
+        shape: Literal["circle", "hex", "square"] | None = None,
         **kwargs: Any,
     ) -> sd.SpatialData:
         """
@@ -232,6 +233,9 @@ class PlotAccessor:
         table_layer: str | None
             Layer of the table to use for coloring if `color` is in :attr:`sdata.table.var_names`. If None, the data in
             :attr:`sdata.table.X` is used for coloring.
+        shape: Literal["circle", "hex", "square"] | None
+            If None (default), the shapes are rendered as they are. Else, if either of "circle", "hex" or "square" is
+            specified, the shapes are converted to a circle/hexagon/square before rendering.
 
         **kwargs : Any
             Additional arguments for customization. This can include:
@@ -276,6 +280,7 @@ class PlotAccessor:
             scale=scale,
             table_name=table_name,
             table_layer=table_layer,
+            shape=shape,
             method=method,
             ds_reduction=kwargs.get("datashader_reduction"),
         )
@@ -304,6 +309,7 @@ class PlotAccessor:
                 transfunc=kwargs.get("transfunc"),
                 table_name=param_values["table_name"],
                 table_layer=param_values["table_layer"],
+                shape=param_values["shape"],
                 zorder=n_steps,
                 method=param_values["method"],
                 ds_reduction=param_values["ds_reduction"],

--- a/src/spatialdata_plot/pl/render_params.py
+++ b/src/spatialdata_plot/pl/render_params.py
@@ -90,6 +90,7 @@ class ShapesRenderParams:
     zorder: int = 0
     table_name: str | None = None
     table_layer: str | None = None
+    shape: Literal["circle", "hex", "square"] | None = None
     ds_reduction: Literal["sum", "mean", "any", "count", "std", "var", "max", "min"] | None = None
 
 


### PR DESCRIPTION
Another feature from squidpy that we want to support here: the new `shape` argument in `render_shapes()` can be set to "circle", "hex" or "square" so that the shapes are converted to and redered as circles/hexagons/squares. If the argument is set to None (default), the shapes are rendered as they are.

First version of the conversion method (@timtreis up to discussion):
- from circle to square/hex: the new shape lies exactly within the original circle
- from (multi)polygon to circle: the convex hull is computed, then we take the center as the mean of the resulting points and choose the radius as the maximum of the distances between the center and every point on the convex hull
- from (multi)polygon to square/hex: chain of (multi)polygon -> circle -> square/hex