### PR TITLE
Enhancement/reduce verbosity

### DIFF
--- a/src/spatialdata_plot/__init__.py
+++ b/src/spatialdata_plot/__init__.py
@@ -2,7 +2,8 @@ from importlib.metadata import version
 
 from . import pl
 from ._logging import set_verbosity
+from ._settings import Verbosity
 
-__all__ = ["pl", "set_verbosity"]
+__all__ = ["pl", "set_verbosity", "Verbosity"]
 
 __version__ = version("spatialdata-plot")

--- a/src/spatialdata_plot/_logging.py
+++ b/src/spatialdata_plot/_logging.py
@@ -1,30 +1,28 @@
 # from https://github.com/scverse/spatialdata/blob/main/src/spatialdata/_logging.py
 
+from __future__ import annotations
+
 import logging
 import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from ._settings import settings
+from ._settings import _VERBOSITY_TO_LOGLEVEL, Verbosity
 
 if TYPE_CHECKING:  # pragma: no cover
     from _pytest.logging import LogCaptureFixture
 
 
-def _setup_logger() -> "logging.Logger":
+def _setup_logger() -> logging.Logger:
     from rich.console import Console
     from rich.logging import RichHandler
 
     logger = logging.getLogger(__name__)
-
-    level = logging.INFO if settings.verbose else logging.WARNING
-    logger.setLevel(level)
-
+    logger.setLevel(logging.WARNING)
     console = Console(force_terminal=True)
     if console.is_jupyter is True:
         console.is_jupyter = False
-
     ch = RichHandler(show_path=False, console=console, show_time=False)
     logger.addHandler(ch)
 
@@ -36,9 +34,31 @@ def _setup_logger() -> "logging.Logger":
 logger = _setup_logger()
 
 
+def set_verbosity(verbosity: Verbosity | int | str) -> None:
+    """Set the verbosity level of the spatialdata-plot logger.
+
+    Mirrors scanpy's verbosity convention.
+
+    Parameters
+    ----------
+    verbosity
+        The verbosity level. Accepts a :class:`Verbosity` enum member,
+        an ``int`` (0–3), or a ``str`` (e.g. ``"warning"``, ``"info"``).
+    """
+    if isinstance(verbosity, str):
+        try:
+            verbosity = Verbosity[verbosity.lower()]
+        except KeyError:
+            msg = f"Cannot set verbosity to {verbosity!r}. Accepted string values are: {list(Verbosity.__members__)}"
+            raise ValueError(msg) from None
+    else:
+        verbosity = Verbosity(verbosity)
+    logger.setLevel(_VERBOSITY_TO_LOGLEVEL[verbosity])
+
+
 @contextmanager
 def logger_warns(
-    caplog: "LogCaptureFixture",
+    caplog: LogCaptureFixture,
     logger: logging.Logger,
     match: str | None = None,
     level: int = logging.WARNING,
@@ -75,8 +95,3 @@ def logger_warns(
         if not any(pattern.search(r.getMessage()) for r in records):
             msgs = [r.getMessage() for r in records]
             raise AssertionError(f"Did not find log matching {match!r} in records: {msgs!r}")
-
-
-def set_verbosity(verbose: bool = True) -> None:
-    level = logging.INFO if verbose else logging.WARNING
-    logger.setLevel(level)

--- a/src/spatialdata_plot/_settings.py
+++ b/src/spatialdata_plot/_settings.py
@@ -1,9 +1,33 @@
-from dataclasses import dataclass
+"""Settings for spatialdata-plot, mirroring scanpy's verbosity pattern."""
+
+from __future__ import annotations
+
+import logging
+from enum import IntEnum
 
 
-@dataclass
-class Settings:
-    verbose: bool = False
+class Verbosity(IntEnum):
+    """Verbosity levels, mirroring scanpy's convention.
+
+    ========  =====  =================
+    Level     Value  Logging level
+    ========  =====  =================
+    error       0    ``logging.ERROR``
+    warning     1    ``logging.WARNING``
+    info        2    ``logging.INFO``
+    debug       3    ``logging.DEBUG``
+    ========  =====  =================
+    """
+
+    error = 0
+    warning = 1
+    info = 2
+    debug = 3
 
 
-settings = Settings()
+_VERBOSITY_TO_LOGLEVEL: dict[Verbosity, int] = {
+    Verbosity.error: logging.ERROR,
+    Verbosity.warning: logging.WARNING,
+    Verbosity.info: logging.INFO,
+    Verbosity.debug: logging.DEBUG,
+}

--- a/tests/pl/test_logging.py
+++ b/tests/pl/test_logging.py
@@ -1,57 +1,65 @@
-import io
 import logging
 
-from spatialdata import SpatialData
+import pytest
 
 import spatialdata_plot
-from tests.conftest import PlotTester, PlotTesterMeta
+from spatialdata_plot._logging import logger
+from spatialdata_plot._settings import Verbosity
 
 
-class TestLogging(PlotTester, metaclass=PlotTesterMeta):
-    def test_default_verbosity_hides_info(self, sdata_blobs: SpatialData):
-        """INFO logs should be hidden by default."""
-        spatialdata_plot.set_verbosity(False)  # ensure default verbosity
+class TestSetVerbosity:
+    @pytest.fixture(autouse=True)
+    def _restore_verbosity(self):
+        """Restore default verbosity after each test."""
+        yield
+        spatialdata_plot.set_verbosity(Verbosity.warning)
 
-        # Replace all handlers temporarily
-        logger = spatialdata_plot._logging.logger
-        original_handlers = logger.handlers[:]
-        logger.handlers = []
+    def test_default_level_is_warning(self):
+        assert logger.level == logging.WARNING
 
-        log_stream = io.StringIO()
-        handler = logging.StreamHandler(log_stream)
-        handler.setLevel(logging.INFO)
-        logger.addHandler(handler)
+    @pytest.mark.parametrize(
+        ("input_value", "expected_level"),
+        [
+            (Verbosity.error, logging.ERROR),
+            (Verbosity.warning, logging.WARNING),
+            (Verbosity.info, logging.INFO),
+            (Verbosity.debug, logging.DEBUG),
+        ],
+    )
+    def test_set_verbosity_with_enum(self, input_value, expected_level):
+        spatialdata_plot.set_verbosity(input_value)
+        assert logger.level == expected_level
 
-        # Run the function
-        sdata_blobs.pl.render_shapes("blobs_circles", method="datashader").pl.show()
+    @pytest.mark.parametrize(
+        ("input_value", "expected_level"),
+        [
+            (0, logging.ERROR),
+            (1, logging.WARNING),
+            (2, logging.INFO),
+            (3, logging.DEBUG),
+        ],
+    )
+    def test_set_verbosity_with_int(self, input_value, expected_level):
+        spatialdata_plot.set_verbosity(input_value)
+        assert logger.level == expected_level
 
-        # Check captured logs — should NOT contain the datashader info message
-        logs = log_stream.getvalue()
-        assert "Using 'datashader' backend" not in logs
+    @pytest.mark.parametrize(
+        ("input_value", "expected_level"),
+        [
+            ("error", logging.ERROR),
+            ("WARNING", logging.WARNING),
+            ("Info", logging.INFO),
+            ("debug", logging.DEBUG),
+        ],
+    )
+    def test_set_verbosity_with_string(self, input_value, expected_level):
+        spatialdata_plot.set_verbosity(input_value)
+        assert logger.level == expected_level
 
-        # Restore original handlers
-        logger.handlers = original_handlers
+    def test_set_verbosity_invalid_string_raises(self):
+        with pytest.raises(ValueError, match="Cannot set verbosity"):
+            spatialdata_plot.set_verbosity("verbose")
 
-    def test_verbose_verbosity_shows_info(self, sdata_blobs):
-        spatialdata_plot.set_verbosity(True)
-
-        # Replace all handlers temporarily
-        logger = spatialdata_plot._logging.logger
-        original_handlers = logger.handlers[:]
-        logger.handlers = []
-
-        log_stream = io.StringIO()
-        handler = logging.StreamHandler(log_stream)
-        handler.setLevel(logging.INFO)
-        logger.addHandler(handler)
-
-        # Run the function
-        sdata_blobs.pl.render_shapes("blobs_circles", method="datashader").pl.show()
-
-        # Check captured logs
-        logs = log_stream.getvalue()
-        assert "Using 'datashader' backend" in logs
-
-        # Restore original handlers
-        logger.handlers = original_handlers
-        spatialdata_plot.set_verbosity(False)
+    def test_set_verbosity_invalid_int_raises(self):
+        with pytest.raises(ValueError):
+            spatialdata_plot.set_verbosity(99)


### PR DESCRIPTION
Set the default logging level to `WARNINGS` instead of `INFO` to avoid printing walls of text when everything is working correctly.

Example usage:
```
import spatialdata_plot
from spatialdata.datasets import blobs

blob = blobs()

# this used to trigger printing of an info message
# now it just outputs the plot
blob.pl.render_shapes("blobs_circles", method='datashader').pl.show()

# to get the old, more verbose behavior
spatialdata_plot.set_verbosity(True)
blob.pl.render_shapes("blobs_circles", method='datashader').pl.show()
```