### PR TITLE
Fix datashader failing with single-category Categorical

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -62,6 +62,21 @@ from spatialdata_plot.pl.utils import (
 _Normalize = Normalize | abc.Sequence[Normalize]
 
 
+def _build_color_key_from_categorical(color_vector: pd.Categorical | np.ndarray | object) -> list[str] | None:
+    """Build a datashader ``color_key`` list from a categorical color vector.
+
+    Returns ``None`` when *color_vector* is not a :class:`pd.Categorical` or
+    has no categories.  Hex colours are stripped of their alpha channel;
+    named colours (e.g. ``"red"``) are passed through unchanged.
+    """
+    if not isinstance(getattr(color_vector, "dtype", None), pd.CategoricalDtype):
+        return None
+    cat_values = color_vector.categories.values  # type: ignore[union-attr]
+    if len(cat_values) == 0:
+        return None
+    return [_hex_no_alpha(x) if isinstance(x, str) and x.startswith("#") else x for x in cat_values]
+
+
 def _split_colorbar_params(params: dict[str, object] | None) -> tuple[dict[str, object], dict[str, object], str | None]:
     """Split colorbar params into layout hints, Matplotlib kwargs, and label override."""
     layout: dict[str, object] = {}
@@ -356,14 +371,7 @@ def _render_shapes(
                     agg = agg.where((agg <= norm.vmin) | (np.isnan(agg)), other=2)
                     agg = agg.where((agg != norm.vmin) | (np.isnan(agg)), other=0.5)
 
-        color_key = (
-            [
-                _hex_no_alpha(x) if isinstance(x, str) and x.startswith("#") else x
-                for x in color_vector.categories.values
-            ]
-            if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 0)
-            else None
-        )
+        color_key = _build_color_key_from_categorical(color_vector)
 
         if color_by_categorical or col_for_color is None:
             ds_cmap = None
@@ -854,14 +862,7 @@ def _render_points(
                     agg = agg.where((agg <= norm.vmin) | (np.isnan(agg)), other=2)
                     agg = agg.where((agg != norm.vmin) | (np.isnan(agg)), other=0.5)
 
-        color_key: list[str] | None = (
-            [
-                _hex_no_alpha(x) if isinstance(x, str) and x.startswith("#") else x
-                for x in color_vector.categories.values
-            ]
-            if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 0)
-            else None
-        )
+        color_key = _build_color_key_from_categorical(color_vector)
         if isinstance(color_vector[0], str) and (
             color_vector is not None and all(len(x) == 9 for x in color_vector) and color_vector[0][0] == "#"
         ):

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -301,7 +301,7 @@ def _render_shapes(
         # Render shapes with datashader
         color_by_categorical = col_for_color is not None and color_source_vector is not None
         aggregate_with_reduction = None
-        if col_for_color is not None and (render_params.groups is None or len(render_params.groups) > 1):
+        if col_for_color is not None and (render_params.groups is None or len(render_params.groups) >= 1):
             if color_by_categorical:
                 agg = cvs.polygons(
                     transformed_element,
@@ -358,7 +358,7 @@ def _render_shapes(
 
         color_key = (
             [_hex_no_alpha(x) for x in color_vector.categories.values]
-            if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 1)
+            if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 0)
             else None
         )
 
@@ -814,7 +814,7 @@ def _render_points(
         if color_by_categorical and transformed_element[col_for_color].values.dtype == object:
             transformed_element[col_for_color] = transformed_element[col_for_color].astype("category")
         aggregate_with_reduction = None
-        if col_for_color is not None and (render_params.groups is None or len(render_params.groups) > 1):
+        if col_for_color is not None and (render_params.groups is None or len(render_params.groups) >= 1):
             if color_by_categorical:
                 agg = cvs.points(transformed_element, "x", "y", agg=ds.by(col_for_color, ds.count()))
             else:
@@ -852,14 +852,10 @@ def _render_points(
                     agg = agg.where((agg != norm.vmin) | (np.isnan(agg)), other=0.5)
 
         color_key: list[str] | None = (
-            list(color_vector.categories.values)
-            if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 1)
+            [_hex_no_alpha(x) for x in color_vector.categories.values]
+            if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 0)
             else None
         )
-
-        # remove alpha from color if it's hex
-        if color_key is not None and all(len(x) == 9 for x in color_key) and color_key[0][0] == "#":
-            color_key = [x[:-2] for x in color_key]
         if isinstance(color_vector[0], str) and (
             color_vector is not None and all(len(x) == 9 for x in color_vector) and color_vector[0][0] == "#"
         ):

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -357,7 +357,10 @@ def _render_shapes(
                     agg = agg.where((agg != norm.vmin) | (np.isnan(agg)), other=0.5)
 
         color_key = (
-            [_hex_no_alpha(x) for x in color_vector.categories.values]
+            [
+                _hex_no_alpha(x) if isinstance(x, str) and x.startswith("#") else x
+                for x in color_vector.categories.values
+            ]
             if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 0)
             else None
         )
@@ -852,7 +855,10 @@ def _render_points(
                     agg = agg.where((agg != norm.vmin) | (np.isnan(agg)), other=0.5)
 
         color_key: list[str] | None = (
-            [_hex_no_alpha(x) for x in color_vector.categories.values]
+            [
+                _hex_no_alpha(x) if isinstance(x, str) and x.startswith("#") else x
+                for x in color_vector.categories.values
+            ]
             if isinstance(color_vector.dtype, pd.CategoricalDtype) and (len(color_vector.categories.values) > 0)
             else None
         )

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -301,7 +301,7 @@ def _render_shapes(
         # Render shapes with datashader
         color_by_categorical = col_for_color is not None and color_source_vector is not None
         aggregate_with_reduction = None
-        if col_for_color is not None and (render_params.groups is None or len(render_params.groups) >= 1):
+        if col_for_color is not None:
             if color_by_categorical:
                 agg = cvs.polygons(
                     transformed_element,
@@ -817,7 +817,7 @@ def _render_points(
         if color_by_categorical and transformed_element[col_for_color].values.dtype == object:
             transformed_element[col_for_color] = transformed_element[col_for_color].astype("category")
         aggregate_with_reduction = None
-        if col_for_color is not None and (render_params.groups is None or len(render_params.groups) >= 1):
+        if col_for_color is not None:
             if color_by_categorical:
                 agg = cvs.points(transformed_element, "x", "y", agg=ds.by(col_for_color, ds.count()))
             else:

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -572,3 +572,30 @@ def test_datashader_colors_points_from_table_obs(sdata_blobs: SpatialData):
         method="datashader",
         size=5,
     ).pl.show()
+
+
+def test_plot_datashader_single_category_points(sdata_blobs: SpatialData):
+    """Datashader should handle a Categorical column with only 1 category (#483)."""
+    n_obs = len(sdata_blobs["blobs_points"])
+    obs = pd.DataFrame(
+        {
+            "instance_id": np.arange(n_obs),
+            "region": pd.Categorical(["blobs_points"] * n_obs),
+            "foo": pd.Categorical(["only_cat"] * n_obs),
+        }
+    )
+    table = TableModel.parse(
+        adata=AnnData(get_standard_RNG().normal(size=(n_obs, 3)), obs=obs),
+        region="blobs_points",
+        region_key="region",
+        instance_key="instance_id",
+    )
+    sdata_blobs["single_cat_table"] = table
+
+    sdata_blobs.pl.render_points(
+        "blobs_points",
+        color="foo",
+        table_name="single_cat_table",
+        method="datashader",
+        size=5,
+    ).pl.show()

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -575,7 +575,14 @@ def test_datashader_colors_points_from_table_obs(sdata_blobs: SpatialData):
 
 
 def test_plot_datashader_single_category_points(sdata_blobs: SpatialData):
-    """Datashader should handle a Categorical column with only 1 category (#483)."""
+    """Datashader with a single-category Categorical must not raise.
+
+    Regression test for https://github.com/scverse/spatialdata-plot/issues/483.
+    Before the fix, color_key was None when there was only 1 category, but ds.by()
+    still produced a 3D DataArray, causing datashader to raise:
+        ValueError: Color key must be provided, with at least as many colors as
+        there are categorical fields
+    """
     n_obs = len(sdata_blobs["blobs_points"])
     obs = pd.DataFrame(
         {

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -976,7 +976,14 @@ def test_plot_can_handle_mixed_numeric_and_color_data(sdata_blobs: SpatialData):
 
 
 def test_plot_datashader_single_category(sdata_blobs: SpatialData):
-    """Datashader should handle a Categorical column with only 1 category (#483)."""
+    """Datashader with a single-category Categorical must not raise.
+
+    Regression test for https://github.com/scverse/spatialdata-plot/issues/483.
+    Before the fix, color_key was None when there was only 1 category, but ds.by()
+    still produced a 3D DataArray, causing datashader to raise:
+        ValueError: Color key must be provided, with at least as many colors as
+        there are categorical fields
+    """
     n_obs = len(sdata_blobs["blobs_polygons"])
     adata = AnnData(get_standard_RNG().normal(size=(n_obs, 10)))
     adata.obs = pd.DataFrame(get_standard_RNG().normal(size=(n_obs, 3)), columns=["a", "b", "c"])

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -973,3 +973,22 @@ def test_plot_can_handle_mixed_numeric_and_color_data(sdata_blobs: SpatialData):
     # Mixed numeric / non-numeric values should raise a TypeError
     with pytest.raises(TypeError, match="contains both numeric and non-numeric values"):
         sdata_blobs.pl.render_shapes(element="blobs_circles", color="mixed_data", na_color="gray").pl.show()
+
+
+def test_plot_datashader_single_category(sdata_blobs: SpatialData):
+    """Datashader should handle a Categorical column with only 1 category (#483)."""
+    n_obs = len(sdata_blobs["blobs_polygons"])
+    adata = AnnData(get_standard_RNG().normal(size=(n_obs, 10)))
+    adata.obs = pd.DataFrame(get_standard_RNG().normal(size=(n_obs, 3)), columns=["a", "b", "c"])
+    adata.obs["category"] = pd.Categorical(["only_cat"] * n_obs)
+    adata.obs["instance_id"] = list(range(n_obs))
+    adata.obs["region"] = "blobs_polygons"
+    table = TableModel.parse(
+        adata=adata,
+        region_key="region",
+        instance_key="instance_id",
+        region="blobs_polygons",
+    )
+    sdata_blobs["table"] = table
+
+    sdata_blobs.pl.render_shapes(element="blobs_polygons", color="category", method="datashader").pl.show()


### PR DESCRIPTION
## Summary
- Fixes #483: datashader raises `ValueError` when rendering shapes/points with a `pd.Categorical` column that has only 1 category
- Changed `color_key` guard from `> 1` to `> 0` so a single-category Categorical still produces a valid color key for datashader
- Changed `groups` guard from `> 1` to `>= 1` so a single group uses categorical aggregation instead of falling back to count-based heatmap
- Used `_hex_no_alpha` in points `color_key` construction for consistency with the shapes path