### PR TITLE
Warn and render na_color when color column is all-NaN

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1102,17 +1102,11 @@ def _set_color_source_vec(
 
         if color_series.isna().all():
             element_label = _format_element_name(element_name)
-            location = f"table '{table_name}'" if table_name is not None else "the element"
             dtype_hint = _build_alignment_dtype_hint(sdata, element, color_series, table_name)
-            if dtype_hint:
-                raise ValueError(
-                    f"Column '{value_to_plot}' for element '{element_label}' contains only missing values after "
-                    f"aligning with {location}. Please ensure the table annotates the element with matching instance "
-                    f"ids.{dtype_hint}"
-                )
+            hint_suffix = f" {dtype_hint.strip()}" if dtype_hint else ""
             logger.warning(
                 f"Column '{value_to_plot}' for element '{element_label}' contains only NaN values; "
-                "rendering with na_color."
+                f"rendering with na_color.{hint_suffix}"
             )
             na_color_arr = np.full(len(color_series), na_color.get_hex_with_alpha())
             return na_color_arr, na_color_arr, False

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -1104,12 +1104,18 @@ def _set_color_source_vec(
             element_label = _format_element_name(element_name)
             location = f"table '{table_name}'" if table_name is not None else "the element"
             dtype_hint = _build_alignment_dtype_hint(sdata, element, color_series, table_name)
-            raise ValueError(
-                f"Column '{value_to_plot}' for element '{element_label}' contains only missing values after aligning "
-                f"with {location}. This usually means the instance ids/indices could not be aligned or converted, so "
-                "colors cannot be determined. Please ensure the table annotates the element with matching instance ids."
-                f"{dtype_hint}"
+            if dtype_hint:
+                raise ValueError(
+                    f"Column '{value_to_plot}' for element '{element_label}' contains only missing values after "
+                    f"aligning with {location}. Please ensure the table annotates the element with matching instance "
+                    f"ids.{dtype_hint}"
+                )
+            logger.warning(
+                f"Column '{value_to_plot}' for element '{element_label}' contains only NaN values; "
+                "rendering with na_color."
             )
+            na_color_arr = np.full(len(color_series), na_color.get_hex_with_alpha())
+            return na_color_arr, na_color_arr, False
 
         kind, processed = _infer_color_data_kind(
             series=color_series,


### PR DESCRIPTION
Fixes #599.

## Summary
- All-NaN color column previously raised a misleading `ValueError` blaming instance-id alignment even when the join succeeded
- When dtypes match (genuine all-NaN case): now emits a warning and renders every element with `na_color`, consistent with partial-NaN behaviour
- When dtypes differ (genuine alignment failure): keeps the error, rephrased to drop the incorrect "could not be aligned" language