### PR TITLE
Fix double .compute() when render_points color= is a native column

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -832,8 +832,13 @@ def _render_points(
     # from the registered points (see above) avoids duplicate-origin ambiguities.
     color_table_name = table_name
 
-    # Reuse color data already loaded from the table to avoid a redundant get_values() call.
-    _preloaded = points_pd_with_color[col_for_color] if added_color_from_table and col_for_color is not None else None
+    # Reuse already-loaded color data to avoid a redundant get_values() call — applies to both
+    # native-column and table-sourced cases, both of which are present in points_pd_with_color.
+    _preloaded = (
+        points_pd_with_color[col_for_color]
+        if col_for_color is not None and col_for_color in points_pd_with_color.columns
+        else None
+    )
 
     color_source_vector, color_vector, _ = _set_color_source_vec(
         sdata=sdata_filt,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -832,8 +832,7 @@ def _render_points(
     # from the registered points (see above) avoids duplicate-origin ambiguities.
     color_table_name = table_name
 
-    # Reuse already-loaded color data to avoid a redundant get_values() call — applies to both
-    # native-column and table-sourced cases, both of which are present in points_pd_with_color.
+    # Reuse already-loaded color data to avoid a redundant get_values() call.
     _preloaded = (
         points_pd_with_color[col_for_color]
         if col_for_color is not None and col_for_color in points_pd_with_color.columns

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -1,5 +1,6 @@
 import math
 
+import dask
 import dask.dataframe
 import datashader as ds
 import matplotlib
@@ -1004,3 +1005,35 @@ def test_no_table_fallback_warning_for_element_column(caplog):
     with logger_no_warns(caplog, logger, match="fallback for color mapping"):
         sdata.pl.render_points("pts", color="cell_type").pl.show()
     plt.close("all")
+
+
+def test_render_points_native_color_column_single_compute():
+    # Regression test for #633: color column native to the points element triggered
+    # two .compute() calls instead of one.
+    dask.config.set({"dataframe.query-planning": False})
+    compute_calls = []
+    original_compute = dask.dataframe.DataFrame.compute
+
+    def counting_compute(self, **kwargs):
+        compute_calls.append(True)
+        return original_compute(self, **kwargs)
+
+    dask.dataframe.DataFrame.compute = counting_compute
+    try:
+        rng = np.random.default_rng(42)
+        n = 100
+        df = pd.DataFrame(
+            {
+                "x": rng.uniform(0, 100, n),
+                "y": rng.uniform(0, 100, n),
+                "cell_type": pd.Categorical(rng.choice(["A", "B", "C"], n)),
+            }
+        )
+        points = PointsModel.parse(df)
+        sdata = SpatialData(points={"pts": points})
+        sdata.pl.render_points("pts", color="cell_type").pl.show()
+        plt.close("all")
+    finally:
+        dask.dataframe.DataFrame.compute = original_compute
+
+    assert len(compute_calls) == 1, f"Expected 1 .compute() call, got {len(compute_calls)}"

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -1,6 +1,5 @@
 import math
 
-import dask
 import dask.dataframe
 import datashader as ds
 import matplotlib
@@ -1005,33 +1004,3 @@ def test_no_table_fallback_warning_for_element_column(caplog):
     with logger_no_warns(caplog, logger, match="fallback for color mapping"):
         sdata.pl.render_points("pts", color="cell_type").pl.show()
     plt.close("all")
-
-
-def test_render_points_native_color_column_single_compute(monkeypatch):
-    # Regression test for #633: color column native to the points element triggered
-    # two .compute() calls instead of one.
-    compute_calls = []
-    original_compute = dask.dataframe.DataFrame.compute
-
-    def counting_compute(self, **kwargs):
-        compute_calls.append(True)
-        return original_compute(self, **kwargs)
-
-    rng = np.random.default_rng(42)
-    n = 100
-    df = pd.DataFrame(
-        {
-            "x": rng.uniform(0, 100, n),
-            "y": rng.uniform(0, 100, n),
-            "cell_type": pd.Categorical(rng.choice(["A", "B", "C"], n)),
-        }
-    )
-    points = PointsModel.parse(df)
-    sdata = SpatialData(points={"pts": points})
-
-    with dask.config.set({"dataframe.query-planning": False}):
-        monkeypatch.setattr(dask.dataframe.DataFrame, "compute", counting_compute)
-        sdata.pl.render_points("pts", color="cell_type").pl.show()
-        plt.close("all")
-
-    assert len(compute_calls) == 1, f"Expected 1 .compute() call, got {len(compute_calls)}"

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -1010,7 +1010,6 @@ def test_no_table_fallback_warning_for_element_column(caplog):
 def test_render_points_native_color_column_single_compute():
     # Regression test for #633: color column native to the points element triggered
     # two .compute() calls instead of one.
-    dask.config.set({"dataframe.query-planning": False})
     compute_calls = []
     original_compute = dask.dataframe.DataFrame.compute
 
@@ -1018,22 +1017,24 @@ def test_render_points_native_color_column_single_compute():
         compute_calls.append(True)
         return original_compute(self, **kwargs)
 
-    dask.dataframe.DataFrame.compute = counting_compute
-    try:
-        rng = np.random.default_rng(42)
-        n = 100
-        df = pd.DataFrame(
-            {
-                "x": rng.uniform(0, 100, n),
-                "y": rng.uniform(0, 100, n),
-                "cell_type": pd.Categorical(rng.choice(["A", "B", "C"], n)),
-            }
-        )
-        points = PointsModel.parse(df)
-        sdata = SpatialData(points={"pts": points})
+    rng = np.random.default_rng(42)
+    n = 100
+    df = pd.DataFrame(
+        {
+            "x": rng.uniform(0, 100, n),
+            "y": rng.uniform(0, 100, n),
+            "cell_type": pd.Categorical(rng.choice(["A", "B", "C"], n)),
+        }
+    )
+    points = PointsModel.parse(df)
+    sdata = SpatialData(points={"pts": points})
+
+    with (
+        dask.config.set({"dataframe.query-planning": False}),
+        pytest.MonkeyPatch().context() as mp,
+    ):
+        mp.setattr(dask.dataframe.DataFrame, "compute", counting_compute)
         sdata.pl.render_points("pts", color="cell_type").pl.show()
         plt.close("all")
-    finally:
-        dask.dataframe.DataFrame.compute = original_compute
 
     assert len(compute_calls) == 1, f"Expected 1 .compute() call, got {len(compute_calls)}"

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -1007,7 +1007,7 @@ def test_no_table_fallback_warning_for_element_column(caplog):
     plt.close("all")
 
 
-def test_render_points_native_color_column_single_compute():
+def test_render_points_native_color_column_single_compute(monkeypatch):
     # Regression test for #633: color column native to the points element triggered
     # two .compute() calls instead of one.
     compute_calls = []
@@ -1029,11 +1029,8 @@ def test_render_points_native_color_column_single_compute():
     points = PointsModel.parse(df)
     sdata = SpatialData(points={"pts": points})
 
-    with (
-        dask.config.set({"dataframe.query-planning": False}),
-        pytest.MonkeyPatch().context() as mp,
-    ):
-        mp.setattr(dask.dataframe.DataFrame, "compute", counting_compute)
+    with dask.config.set({"dataframe.query-planning": False}):
+        monkeypatch.setattr(dask.dataframe.DataFrame, "compute", counting_compute)
         sdata.pl.render_points("pts", color="cell_type").pl.show()
         plt.close("all")
 


### PR DESCRIPTION
## Summary

- `render_points(color=<native_col>)` was calling `dd.DataFrame.compute()` twice: once explicitly to load the points (render.py:747) and again inside `_set_color_source_vec` via a redundant `get_values()` call (utils.py:1077).
- Root cause: the `_preloaded` shortcut only fired when `added_color_from_table=True`. For element-native color columns the flag stayed `False`, so `_set_color_source_vec` fell back to a fresh `get_values()` call.
- Fix: widen the condition to `col_for_color is not None and col_for_color in points_pd_with_color.columns`, which is `True` for both native-column and table-sourced cases.

Closes #633.

## Test plan

- [ ] `test_render_points_native_color_column_single_compute` — patches `dd.DataFrame.compute` to count calls and asserts exactly 1 for a native categorical color column