### PR TITLE
Fix render_labels silently accepting fill_alpha=0 and outline_alpha=0

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -1764,6 +1764,11 @@ def _render_labels(
     if effective_outline_color is None and col_for_color is None and render_params.color is not None:
         effective_outline_color = render_params.color
 
+    if render_params.fill_alpha == 0.0 and render_params.outline_alpha == 0.0:
+        raise ValueError(
+            "Parameters 'fill_alpha' and 'outline_alpha' cannot both be 0. Set at least one to a positive value."
+        )
+
     # default case: no contour, just fill
     # since contour_px is passed to skimage.morphology.erosion to create the contour,
     # any border thickness is only within the label, not outside. Therefore, the case


### PR DESCRIPTION
## Summary
- Fixes #630: `render_labels(fill_alpha=0, outline_alpha=0)` produced an empty plot (alpha=0 overlay) instead of erroring.
- The first branch of the dispatch chain matched `fill_alpha == outline_alpha`, routing `(0, 0)` to the fill-only path and leaving the existing `else: raise ValueError(...)` unreachable.
- Add an explicit guard before the dispatch chain so the documented error is actually raised.