### PR TITLE
Reject contour_px=1 in render_labels

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -760,8 +760,9 @@ class PlotAccessor:
             color names (must match the number of groups), a single named palette or matplotlib colormap name, or
             ``None``.
         contour_px : int, default 3
-            Draw contour of specified width for each segment. If `None`, fills entire segment, see:
-            func:`skimage.morphology.erosion`.
+            Draw contour of specified width for each segment. Must be >= 2; ``contour_px=1`` is rejected
+            because a 1x1 erosion is the identity transformation and produces no visible outline. If
+            ``None``, fills entire segment, see :func:`skimage.morphology.erosion`.
         cmap : Colormap | str | None, optional
             Colormap for continuous annotations using 'color', see :class:`matplotlib.colors.Colormap`.
             For categorical data, use ``palette`` instead.

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2368,14 +2368,11 @@ def _type_check_params(param_dict: dict[str, Any], element_type: str) -> dict[st
         else:
             param_dict["outline_color"] = Color(outline_color)
 
-    if contour_px is not None:
-        if contour_px <= 0:
-            raise ValueError("Parameter 'contour_px' must be a positive number.")
-        if contour_px == 1:
-            raise ValueError(
-                "Parameter 'contour_px' must be >= 2; contour_px=1 produces no visible outline "
-                "(a 1x1 erosion is the identity transformation)."
-            )
+    if contour_px is not None and contour_px < 2:
+        raise ValueError(
+            "Parameter 'contour_px' must be >= 2; values below 2 produce no visible outline "
+            "(a 1x1 erosion is the identity transformation)."
+        )
 
     alpha = param_dict.get("alpha")
     if alpha is not None:

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2368,8 +2368,14 @@ def _type_check_params(param_dict: dict[str, Any], element_type: str) -> dict[st
         else:
             param_dict["outline_color"] = Color(outline_color)
 
-    if contour_px is not None and contour_px <= 0:
-        raise ValueError("Parameter 'contour_px' must be a positive number.")
+    if contour_px is not None:
+        if contour_px <= 0:
+            raise ValueError("Parameter 'contour_px' must be a positive number.")
+        if contour_px == 1:
+            raise ValueError(
+                "Parameter 'contour_px' must be >= 2; contour_px=1 produces no visible outline "
+                "(a 1x1 erosion is the identity transformation)."
+            )
 
     alpha = param_dict.get("alpha")
     if alpha is not None:


### PR DESCRIPTION
## Summary
- `render_labels(..., contour_px=1)` silently produced a blank outline because `footprint_rectangle((1, 1))` is the identity for erosion, so `seg - erosion(seg)` was zero everywhere.
- Now raises `ValueError` with guidance to use `contour_px >= 2`, consistent with the existing positive-number check and the silent-failure fix in #630.
- Updated the `contour_px` docstring to document the requirement.

Closes #631.