### PR TITLE
Reject legend_loc='on data' loudly in pl.show()

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -1147,6 +1147,14 @@ class PlotAccessor:
             legend_fontoutline = legend_params.get("fontoutline", legend_fontoutline)
             na_in_legend = legend_params.get("na_in_legend", na_in_legend)
 
+        if legend_loc == "on data":
+            raise ValueError(
+                "legend_loc='on data' is not supported in spatialdata-plot: it requires "
+                "scatter embedding coordinates that do not exist for shapes, points, "
+                "labels, or image channels. Use 'right margin' (default), None, or any "
+                "matplotlib legend location string (e.g. 'upper right')."
+            )
+
         legend_params_obj = LegendParams(
             legend_fontsize=legend_fontsize,
             legend_fontweight=legend_fontweight,

--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -1148,12 +1148,7 @@ class PlotAccessor:
             na_in_legend = legend_params.get("na_in_legend", na_in_legend)
 
         if legend_loc == "on data":
-            raise ValueError(
-                "legend_loc='on data' is not supported in spatialdata-plot: it requires "
-                "scatter embedding coordinates that do not exist for shapes, points, "
-                "labels, or image channels. Use 'right margin' (default), None, or any "
-                "matplotlib legend location string (e.g. 'upper right')."
-            )
+            raise ValueError("legend_loc='on data' is not supported in spatialdata-plot.")
 
         legend_params_obj = LegendParams(
             legend_fontsize=legend_fontsize,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -1153,12 +1153,6 @@ def _draw_channel_legend(
         palette_dict[entry.channel_name] = entry.color_hex
 
     legend_loc = legend_params.legend_loc
-    if legend_loc == "on data":
-        logger.warning(
-            "legend_loc='on data' is not supported for channel legends (no scatter coordinates); "
-            "falling back to 'right margin'."
-        )
-        legend_loc = "right margin"
 
     categories = pd.Categorical(list(palette_dict))
 


### PR DESCRIPTION
## Summary
- Closes #624
- `legend_loc="on data"` is meaningless in spatialdata-plot — there are no scatter embedding coordinates for shapes, points, labels, or image channels. It previously crashed deep in scanpy with `ValueError: Grouper and axis must be same length` (categorical path) or warned and fell back (channel-legend path).
- `pl.show()` now raises a clear `ValueError` at the API surface, after the `legend_params` dict override resolves the final `legend_loc`, so all entry paths are covered.
- The now-dead warn-and-fallback in `_draw_channel_legend` is removed.