### PR TITLE
Replace assert with direct call for table validation

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2577,7 +2577,7 @@ def _type_check_params(param_dict: dict[str, Any], element_type: str) -> dict[st
 
         return True  # not using any table
 
-    assert _ensure_table_and_layer_exist_in_sdata(param_dict.get("sdata"), table_name, table_layer)
+    _ensure_table_and_layer_exist_in_sdata(param_dict.get("sdata"), table_name, table_layer)
 
     method = param_dict.get("method")
     if method not in ["matplotlib", "datashader", None]:


### PR DESCRIPTION
## Summary
- Replace `assert _ensure_table_and_layer_exist_in_sdata(...)` with a direct call in `_type_check_params` (`src/spatialdata_plot/pl/utils.py`).
- `assert` is stripped under `python -O` / `PYTHONOPTIMIZE=1`, silently bypassing user-input validation. The function already raises `ValueError` on failure; its return value is unused, only the side effect matters.

Fixes #616.