### PR TITLE
Infer fig from ax in show() instead of requiring it

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -4,7 +4,7 @@ import contextlib
 import sys
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -1003,7 +1003,7 @@ class PlotAccessor:
             legend_params,
         )
 
-        if fig is not None and not isinstance(ax, Sequence):
+        if fig is not None:
             warnings.warn(
                 "`fig` is being deprecated as an argument to `PlotAccessor.show` in spatialdata-plot. "
                 "To use a custom figure, create axes from it and pass them via `ax` instead: "

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -294,14 +294,10 @@ def _prepare_params_plot(
     elif num_panels > 1:
         if not isinstance(ax, Sequence):
             raise TypeError(f"Expected `ax` to be a `Sequence`, but got {type(ax).__name__}")
-        if ax is not None and len(ax) != num_panels:
+        if len(ax) != num_panels:
             raise ValueError(f"Len of `ax`: {len(ax)} is not equal to number of panels: {num_panels}.")
         if fig is None:
-            # TODO(#579): infer fig from ax[0].get_figure() instead of requiring it
-            raise ValueError(
-                f"Invalid value of `fig`: {fig}. If a list of `Axes` is passed, a `Figure` must also be specified."
-            )
-        assert ax is None or isinstance(ax, Sequence), f"Invalid type of `ax`: {type(ax)}, expected `Sequence`."
+            fig = ax[0].get_figure()
         axs = ax
         if dpi is not None:
             fig.set_dpi(dpi)
@@ -309,7 +305,13 @@ def _prepare_params_plot(
         axs = None
         if ax is None:
             fig, ax = plt.subplots(figsize=figsize, dpi=resolved_dpi, constrained_layout=True)
-        elif isinstance(ax, Axes):
+        else:
+            if isinstance(ax, Sequence):
+                if len(ax) != 1:
+                    raise ValueError(f"Len of `ax`: {len(ax)} is not equal to number of panels: {num_panels}.")
+                ax = ax[0]
+            if not isinstance(ax, Axes):
+                raise TypeError(f"Expected `ax` to be an `Axes` or a `Sequence` of `Axes`, but got {type(ax).__name__}")
             fig = ax.get_figure()
             if dpi is not None:
                 fig.set_dpi(dpi)

--- a/tests/pl/test_show.py
+++ b/tests/pl/test_show.py
@@ -136,14 +136,33 @@ def test_fig_parameter_default_no_warning(sdata_blobs: SpatialData):
     plt.close("all")
 
 
-def test_fig_parameter_no_warning_with_ax_list(sdata_blobs: SpatialData):
-    """Passing fig= with a list of axes should not warn (fig is still required there)."""
+def test_fig_parameter_warns_with_ax_list(sdata_blobs: SpatialData):
+    """Passing fig= alongside a list of axes should also emit the deprecation (regression for #625)."""
     set_transformation(sdata_blobs["blobs_image"], Identity(), "second_cs")
     fig, axs = plt.subplots(1, 2)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+    with pytest.warns(DeprecationWarning, match="`fig` is being deprecated"):
         sdata_blobs.pl.render_images(element="blobs_image").pl.show(fig=fig, ax=list(axs), show=False)
     plt.close("all")
+
+
+def test_show_ax_list_infers_fig(sdata_blobs: SpatialData):
+    """show(ax=[...]) should infer fig from the axes without requiring fig= (regression for #625)."""
+    set_transformation(sdata_blobs["blobs_image"], Identity(), "second_cs")
+    fig, axs = plt.subplots(1, 2)
+    sdata_blobs.pl.render_images(element="blobs_image").pl.show(ax=list(axs), show=False)
+    for ax in axs:
+        assert ax.get_figure() is fig
+        assert len(ax.get_images()) > 0
+    plt.close(fig)
+
+
+def test_show_single_panel_accepts_ax_list(sdata_blobs: SpatialData):
+    """show(ax=[ax]) for a single coordinate system should be accepted (regression for #625)."""
+    fig, ax = plt.subplots()
+    sdata_blobs.pl.render_images(element="blobs_image").pl.show(ax=[ax], show=False)
+    assert ax.get_figure() is fig
+    assert len(ax.get_images()) > 0
+    plt.close(fig)
 
 
 def test_frameon_false_multi_panel(sdata_blobs: SpatialData):


### PR DESCRIPTION
## Summary
- `pl.show(ax=[...])` now infers `fig` from `ax[0].get_figure()` instead of raising when `fig=` is omitted, mirroring the single-axis path.
- Single-panel branch now accepts a 1-element `Sequence` of axes (previously left `fig` unbound and tripped a downstream `isinstance(ax, Axes)` assert).
- The `fig=` deprecation warning now also fires when paired with a list of axes.

Closes #625. Closes #579.
