### PR TITLE
Parameter `palette` can now be used without specifying `groups`

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2479,9 +2479,7 @@ def _type_check_params(param_dict: dict[str, Any], element_type: str) -> dict[st
     palette_group = param_dict.get("palette")
     if element_type in ["shapes", "points", "labels"] and palette_group is not None and not isinstance(palette, dict):
         groups = param_dict.get("groups")
-        if groups is None:
-            raise ValueError("When specifying 'palette', 'groups' must also be specified.")
-        if len(groups) != len(palette_group):
+        if groups is not None and len(groups) != len(palette_group):
             raise ValueError(
                 f"The length of 'palette' and 'groups' must be the same, length is {len(palette_group)} and"
                 f"{len(groups)} respectively."

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -275,6 +275,23 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
             "blobs_polygons", color="cluster", groups=["c2", "c1"], palette=["green", "yellow"]
         ).pl.show()
 
+    def test_render_shapes_list_palette_without_groups(self, sdata_blobs: SpatialData):
+        # Regression test for #605: a list palette should map to categories in their natural order
+        # without requiring groups= to enumerate every category.
+        sdata_blobs["table"].obs["region"] = pd.Categorical(["blobs_polygons"] * sdata_blobs["table"].n_obs)
+        sdata_blobs["table"].uns["spatialdata_attrs"]["region"] = "blobs_polygons"
+        sdata_blobs.shapes["blobs_polygons"]["cluster"] = "c1"
+        sdata_blobs.shapes["blobs_polygons"].iloc[3:5, 1] = "c2"
+        sdata_blobs.shapes["blobs_polygons"]["cluster"] = sdata_blobs.shapes["blobs_polygons"]["cluster"].astype(
+            "category"
+        )
+
+        _, ax = plt.subplots()
+        sdata_blobs.pl.render_shapes("blobs_polygons", color="cluster", palette=["green", "yellow"]).pl.show(ax=ax)
+        legend = ax.get_legend()
+        assert legend is not None
+        assert {t.get_text() for t in legend.get_texts()} == {"c1", "c2"}
+
     def test_plot_colorbar_respects_input_limits(self, sdata_blobs: SpatialData):
         sdata_blobs["table"].obs["region"] = pd.Categorical(["blobs_polygons"] * sdata_blobs["table"].n_obs)
         sdata_blobs["table"].uns["spatialdata_attrs"]["region"] = "blobs_polygons"


### PR DESCRIPTION
Closes #605.

`_validate_render_params` raised `ValueError: When specifying 'palette', 'groups' must also be specified` whenever `palette=list` was supplied without `groups=`. The dict path has no such restriction, so a list of three colors against three categories forced users to redundantly re-list every category just to satisfy validation.

Dropped the `groups is None` requirement; the existing length check at `_get_colors_for_categorical_obs` already raises if the list does not match the category count, and the natural-order mapping there now applies. Regression test in `test_render_shapes.py` asserts the legend matches the underlying categories.