### PR TITLE
Added guard against annotated `instance_id==0` elements in `render_labels`

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -1654,6 +1654,13 @@ def _render_labels(
         _, region_key, instance_key = get_table_keys(sdata[table_name])
         table = sdata[table_name][sdata[table_name].obs[region_key].isin([element])]
 
+        if (table.obs[instance_key] == 0).any():
+            raise ValueError(
+                f"Table '{table_name}' contains instance_id=0 for element '{element}'. Label value 0 is "
+                "reserved for background and must not appear in the annotation table. Remove the row with "
+                "instance_id=0 before plotting."
+            )
+
         # get instance id based on subsetted table
         instance_id = np.unique(table.obs[instance_key].values)
 

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -490,3 +490,35 @@ def test_render_labels_rejects_float_dtype(dtype):
             sdata.pl.render_labels("lbl").pl.show(ax=ax)
     finally:
         plt.close(fig)
+
+
+def test_render_labels_rejects_background_instance_id_in_table():
+    # Regression test for #607: a table row with instance_id=0 (background label)
+    # used to crash with `IndexError: Boolean index has wrong length` from deep
+    # inside the color-vector mask, with no mention of background label 0.
+    labels_data = np.zeros((20, 20), dtype=np.int32)
+    labels_data[3:8, 3:8] = 1
+    labels_data[12:17, 12:17] = 2
+    labels = Labels2DModel.parse(labels_data, dims=["y", "x"])
+
+    obs = pd.DataFrame(
+        {
+            "region": pd.Categorical(["lbl"] * 3),
+            "instance_id": [0, 1, 2],
+            "score": [99.0, 1.0, 2.0],
+        }
+    )
+    table = TableModel.parse(
+        AnnData(X=np.zeros((3, 1)), obs=obs),
+        region="lbl",
+        region_key="region",
+        instance_key="instance_id",
+    )
+    sdata = SpatialData(labels={"lbl": labels}, tables={"t": table})
+
+    fig, ax = plt.subplots()
+    try:
+        with pytest.raises(ValueError, match=r"instance_id=0.*background"):
+            sdata.pl.render_labels("lbl", color="score", table_name="t").pl.show(ax=ax)
+    finally:
+        plt.close(fig)

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -493,9 +493,8 @@ def test_render_labels_rejects_float_dtype(dtype):
 
 
 def test_render_labels_rejects_background_instance_id_in_table():
-    # Regression test for #607: a table row with instance_id=0 (background label)
-    # used to crash with `IndexError: Boolean index has wrong length` from deep
-    # inside the color-vector mask, with no mention of background label 0.
+    # Regression test for #607: table row with instance_id=0 (background)
+    # used to crash with obnscure error.
     labels_data = np.zeros((20, 20), dtype=np.int32)
     labels_data[3:8, 3:8] = 1
     labels_data[12:17, 12:17] = 2


### PR DESCRIPTION
Closes #607.

When the annotation table for `render_labels` includes a row with `instance_id=0`, downstream masking would fail with `IndexError: Boolean index has wrong length` from inside the color-vector path: SpatialData's foreground-only `get_values` returned one fewer entry than the table's `instance_id` array, and the mask at `render.py:1673` mismatched. Nothing in the traceback mentioned background label 0.

Added an explicit check after the table is subset to the element: if `instance_id=0` is present, raise a `ValueError` naming the table, element, and the fix (remove the row). Regression test in `test_render_labels.py`.