### PR TITLE
Bump gallery thumbnail slot height to 300px

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -7,7 +7,7 @@ div.cell_output table.dataframe {
    of the underlying image aspect ratio. Image is contained (not cropped)
    on a white background, centred in the slot. */
 .sd-card-img-top {
-    height: 240px;
+    height: 300px;
     width: 100%;
     object-fit: contain;
     background: #ffffff;


### PR DESCRIPTION
## Summary

Follow-up to #663. The 240px slot was visually too small once live; bumping to 300px gives the thumbnails more presence in the gallery grid.