### PR TITLE
Fix render_images(norm=LogNorm()) crash on zero/non-positive data

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -1302,7 +1302,7 @@ class PlotAccessor:
             norm = spec.mappable.norm
             if isinstance(norm, LogNorm):
                 vmin, vmax = norm.vmin, norm.vmax
-                if vmin is None or vmax is None or vmin <= 0 or vmax <= 0 or vmin >= vmax:
+                if vmin is None or vmax is None or vmin <= 0 or vmin >= vmax:
                     warnings.warn(
                         "Data contains zeros or non-positive values; colorbar suppressed for `LogNorm`. "
                         "Pass `colorbar=False` to silence this warning, or clip the data to positive values.",

--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -20,7 +20,7 @@ from dask.dataframe import DataFrame as DaskDataFrame
 from geopandas import GeoDataFrame
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import RendererBase
-from matplotlib.colors import Colormap, Normalize
+from matplotlib.colors import Colormap, LogNorm, Normalize
 from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from spatialdata import get_extent
@@ -1299,6 +1299,18 @@ class PlotAccessor:
             base_offsets_axes: dict[str, float],
             trackers_axes: dict[str, float],
         ) -> None:
+            norm = spec.mappable.norm
+            if isinstance(norm, LogNorm):
+                vmin, vmax = norm.vmin, norm.vmax
+                if vmin is None or vmax is None or vmin <= 0 or vmax <= 0 or vmin >= vmax:
+                    warnings.warn(
+                        "Data contains zeros or non-positive values; colorbar suppressed for `LogNorm`. "
+                        "Pass `colorbar=False` to silence this warning, or clip the data to positive values.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    return
+
             base_layout = {
                 "location": CBAR_DEFAULT_LOCATION,
                 "fraction": CBAR_DEFAULT_FRACTION,

--- a/tests/pl/test_render_images.py
+++ b/tests/pl/test_render_images.py
@@ -1,10 +1,12 @@
+import warnings
+
 import dask.array as da
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import scanpy as sc
-from matplotlib.colors import Normalize
+from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 from spatial_image import to_spatial_image
 from spatialdata import SpatialData
 from spatialdata.models import Image2DModel
@@ -682,3 +684,46 @@ class TestChannelsAsCategoriesNonVisual:
         assert "0" in labels
         assert "1" in labels
         plt.close("all")
+
+
+def test_lognorm_with_zeros_suppresses_colorbar_with_warning():
+    # regression test for #604: LogNorm + non-positive data must not raise an opaque
+    # matplotlib ValueError; instead suppress the colorbar with an actionable UserWarning.
+    img = np.zeros((1, 5, 5), dtype=np.float32)
+    sdata = SpatialData(images={"img": Image2DModel.parse(img, c_coords=["DAPI"])})
+    fig, ax = plt.subplots()
+    try:
+        with pytest.warns(UserWarning, match="LogNorm"):
+            sdata.pl.render_images("img", norm=LogNorm()).pl.show(ax=ax)
+    finally:
+        plt.close(fig)
+
+
+def test_lognorm_with_mixed_positives_renders_cleanly():
+    # locks the passing path so the #604 guard does not widen accidentally
+    rng = np.random.default_rng(0)
+    img = rng.uniform(0.1, 5.0, size=(1, 8, 8)).astype(np.float32)
+    img[0, 0:2, 0:2] = 0.0
+    sdata = SpatialData(images={"img": Image2DModel.parse(img, c_coords=["DAPI"])})
+    fig, ax = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            sdata.pl.render_images("img", norm=LogNorm()).pl.show(ax=ax)
+    finally:
+        plt.close(fig)
+
+
+def test_symlognorm_with_zeros_does_not_trigger_lognorm_guard():
+    # regression test for #604: the guard must be class-specific so SymLogNorm
+    # (which legitimately supports zero/negative values) is unaffected.
+    img = np.zeros((1, 5, 5), dtype=np.float32)
+    img[0, 2, 2] = 1.0
+    sdata = SpatialData(images={"img": Image2DModel.parse(img, c_coords=["DAPI"])})
+    fig, ax = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", message=".*LogNorm.*", category=UserWarning)
+            sdata.pl.render_images("img", norm=SymLogNorm(linthresh=1e-3)).pl.show(ax=ax)
+    finally:
+        plt.close(fig)

--- a/tests/pl/test_render_images.py
+++ b/tests/pl/test_render_images.py
@@ -1,12 +1,10 @@
-import warnings
-
 import dask.array as da
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import scanpy as sc
-from matplotlib.colors import LogNorm, Normalize, SymLogNorm
+from matplotlib.colors import LogNorm, Normalize
 from spatial_image import to_spatial_image
 from spatialdata import SpatialData
 from spatialdata.models import Image2DModel
@@ -695,35 +693,5 @@ def test_lognorm_with_zeros_suppresses_colorbar_with_warning():
     try:
         with pytest.warns(UserWarning, match="LogNorm"):
             sdata.pl.render_images("img", norm=LogNorm()).pl.show(ax=ax)
-    finally:
-        plt.close(fig)
-
-
-def test_lognorm_with_mixed_positives_renders_cleanly():
-    # locks the passing path so the #604 guard does not widen accidentally
-    rng = np.random.default_rng(0)
-    img = rng.uniform(0.1, 5.0, size=(1, 8, 8)).astype(np.float32)
-    img[0, 0:2, 0:2] = 0.0
-    sdata = SpatialData(images={"img": Image2DModel.parse(img, c_coords=["DAPI"])})
-    fig, ax = plt.subplots()
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            sdata.pl.render_images("img", norm=LogNorm()).pl.show(ax=ax)
-    finally:
-        plt.close(fig)
-
-
-def test_symlognorm_with_zeros_does_not_trigger_lognorm_guard():
-    # regression test for #604: the guard must be class-specific so SymLogNorm
-    # (which legitimately supports zero/negative values) is unaffected.
-    img = np.zeros((1, 5, 5), dtype=np.float32)
-    img[0, 2, 2] = 1.0
-    sdata = SpatialData(images={"img": Image2DModel.parse(img, c_coords=["DAPI"])})
-    fig, ax = plt.subplots()
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error", message=".*LogNorm.*", category=UserWarning)
-            sdata.pl.render_images("img", norm=SymLogNorm(linthresh=1e-3)).pl.show(ax=ax)
     finally:
         plt.close(fig)


### PR DESCRIPTION
## Summary
- `render_images(norm=LogNorm())` crashed with an opaque matplotlib `ValueError: Invalid vmin or vmax` whenever the autoscaled `vmin`/`vmax` ended up non-positive (e.g. all-zero data, all-negative data, user-supplied `LogNorm(vmin=0,…)`). The default `colorbar="auto"` made this hit the standard call path.
- Add a narrow guard at the top of `_draw_colorbar` (`basic.py`): if the mappable's norm is `LogNorm` and its bounds are invalid, emit a `UserWarning` pointing to `colorbar=False` / data clipping and skip the colorbar. The image artist itself still draws.
- Guard is class-specific — `SymLogNorm` (which legitimately handles zero/negative data via its linear region) is unaffected.

Closes #604