### PR TITLE
Raise on obs/var key collision in table-based coloring

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -58,6 +58,7 @@ from spatialdata_plot.pl.render_params import (
 )
 from spatialdata_plot.pl.utils import (
     _ax_show_and_transform,
+    _check_obs_var_shadow,
     _convert_shapes,
     _datashader_canvas_from_dataframe,
     _decorate_axs,
@@ -369,6 +370,8 @@ def _render_shapes(
     col_for_color = render_params.col_for_color
     groups = render_params.groups
     table_layer = render_params.table_layer
+
+    _check_obs_var_shadow(sdata, element, col_for_color, render_params.table_name)
 
     sdata_filt = sdata.filter_by_coordinate_system(
         coordinate_system=coordinate_system,
@@ -765,6 +768,8 @@ def _render_points(
     color = render_params.color.get_hex() if render_params.color else None
     groups = render_params.groups
     palette = render_params.palette
+
+    _check_obs_var_shadow(sdata, element, col_for_color, table_name)
 
     if isinstance(groups, str):
         groups = [groups]
@@ -1686,6 +1691,8 @@ def _render_labels(
     col_for_color = render_params.col_for_color
     groups = render_params.groups
     scale = render_params.scale
+
+    _check_obs_var_shadow(sdata, element, col_for_color, table_name)
 
     sdata_filt = sdata.filter_by_coordinate_system(
         coordinate_system=coordinate_system,

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -64,7 +64,7 @@ from spatialdata import (
 )
 from spatialdata._core.query.relational_query import _locate_value
 from spatialdata._types import ArrayLike
-from spatialdata.models import Image2DModel, Labels2DModel, SpatialElement, TableModel, get_table_keys
+from spatialdata.models import Image2DModel, Labels2DModel, SpatialElement, get_table_keys
 from spatialdata.transformations.operations import get_transformation
 from spatialdata.transformations.transformations import Scale, Translation
 from spatialdata.transformations.transformations import Sequence as TransformSequence
@@ -110,26 +110,30 @@ def _check_obs_var_shadow(
     value_to_plot: str | None,
     table_name: str | None,
 ) -> None:
-    """Raise if `value_to_plot` exists in both `table.obs.columns` and `table.var_names`.
+    """Raise if ``value_to_plot`` exists in both ``table.obs.columns`` and ``table.var_names``.
 
-    Upstream `_get_table_origins` uses an `elif` chain, so a key that lives in both
-    locations is silently resolved to `obs` — masking the user's likely intent of
-    plotting gene expression. Catch this here before any value fetch.
+    Upstream ``_get_table_origins`` uses an ``elif`` chain, so a key that lives in
+    both locations is silently resolved to ``obs`` — masking the user's likely
+    intent of plotting gene expression. Catch this here before any value fetch.
+    Any ``None`` parameter short-circuits the check.
     """
-    if value_to_plot is None or table_name is None or sdata is None or table_name not in sdata.tables:
+    if (
+        value_to_plot is None
+        or table_name is None
+        or element_name is None
+        or sdata is None
+        or table_name not in sdata.tables
+    ):
+        return
+    if table_name not in get_element_annotators(sdata, element_name):
         return
     table = sdata.tables[table_name]
-    if value_to_plot not in table.obs.columns or value_to_plot not in table.var_names:
-        return
-    region = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
-    annotates_element = element_name in region if isinstance(region, list) else element_name == region
-    if not annotates_element:
-        return
-    raise ValueError(
-        f"Color key '{value_to_plot}' is ambiguous: it exists in both "
-        f"`table['{table_name}'].obs.columns` and `table['{table_name}'].var_names`. "
-        "Rename one of them (or drop the obs column) so the intended source is unambiguous."
-    )
+    if value_to_plot in table.obs.columns and value_to_plot in table.var_names:
+        raise ValueError(
+            f"`color={value_to_plot!r}` is ambiguous: it exists in both "
+            f"`table[{table_name!r}].obs.columns` and `table[{table_name!r}].var_names`. "
+            "Rename one of them (or drop the obs column) so the intended source is unambiguous."
+        )
 
 
 def _gate_palette_and_groups(

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -64,7 +64,7 @@ from spatialdata import (
 )
 from spatialdata._core.query.relational_query import _locate_value
 from spatialdata._types import ArrayLike
-from spatialdata.models import Image2DModel, Labels2DModel, SpatialElement, get_table_keys
+from spatialdata.models import Image2DModel, Labels2DModel, SpatialElement, TableModel, get_table_keys
 from spatialdata.transformations.operations import get_transformation
 from spatialdata.transformations.transformations import Scale, Translation
 from spatialdata.transformations.transformations import Sequence as TransformSequence
@@ -102,6 +102,34 @@ _RENDER_CMD_TO_CS_FLAG: dict[str, str] = {
     "render_points": "has_points",
     "render_labels": "has_labels",
 }
+
+
+def _check_obs_var_shadow(
+    sdata: SpatialData | None,
+    element_name: str | None,
+    value_to_plot: str | None,
+    table_name: str | None,
+) -> None:
+    """Raise if `value_to_plot` exists in both `table.obs.columns` and `table.var_names`.
+
+    Upstream `_get_table_origins` uses an `elif` chain, so a key that lives in both
+    locations is silently resolved to `obs` — masking the user's likely intent of
+    plotting gene expression. Catch this here before any value fetch.
+    """
+    if value_to_plot is None or table_name is None or sdata is None or table_name not in sdata.tables:
+        return
+    table = sdata.tables[table_name]
+    if value_to_plot not in table.obs.columns or value_to_plot not in table.var_names:
+        return
+    region = table.uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY]
+    annotates_element = element_name in region if isinstance(region, list) else element_name == region
+    if not annotates_element:
+        return
+    raise ValueError(
+        f"Color key '{value_to_plot}' is ambiguous: it exists in both "
+        f"`table['{table_name}'].obs.columns` and `table['{table_name}'].var_names`. "
+        "Rename one of them (or drop the obs column) so the intended source is unambiguous."
+    )
 
 
 def _gate_palette_and_groups(

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -422,6 +422,56 @@ def test_color_column_collision_on_annotating_table_raises():
     sdata.pl.render_shapes("s", color="#ffa500")
 
 
+def test_color_key_obs_var_shadow_raises():
+    # regression test for #621: when the same key exists in both `table.obs.columns`
+    # and `table.var_names`, upstream `_get_table_origins` silently returns only the
+    # obs origin (elif chain). Surface the ambiguity at the plotting layer instead.
+    pts = PointsModel.parse(pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0], "y": [1.0, 2.0, 3.0, 4.0]}))
+    obs = pd.DataFrame(
+        {
+            "instance_id": [0, 1, 2, 3],
+            "region": ["pts"] * 4,
+            "GeneA": [0.9, 0.8, 0.7, 0.6],
+        }
+    )
+    obs.index = obs.index.astype(str)
+    X = np.array([[1.0, 0.5], [0.8, 0.2], [0.3, 0.9], [0.1, 0.7]])
+    table = TableModel.parse(
+        AnnData(X=X, obs=obs, var=pd.DataFrame(index=["GeneA", "GeneB"])),
+        region=["pts"],
+        region_key="region",
+        instance_key="instance_id",
+    )
+    sdata = SpatialData(points={"pts": pts}, tables={"t": table})
+
+    with pytest.raises(ValueError, match=r"'GeneA'.*ambiguous.*obs\.columns.*var_names"):
+        sdata.pl.render_points("pts", color="GeneA", table_name="t").pl.show()
+
+    # Negative control: only in var → no error.
+    obs_var_only = pd.DataFrame(
+        {"instance_id": [0, 1, 2, 3], "region": ["pts"] * 4},
+        index=[str(i) for i in range(4)],
+    )
+    table_var_only = TableModel.parse(
+        AnnData(X=X, obs=obs_var_only, var=pd.DataFrame(index=["GeneA", "GeneB"])),
+        region=["pts"],
+        region_key="region",
+        instance_key="instance_id",
+    )
+    sdata_var_only = SpatialData(points={"pts": pts}, tables={"t": table_var_only})
+    sdata_var_only.pl.render_points("pts", color="GeneA", table_name="t").pl.show()
+
+    # Negative control: only in obs → no error.
+    table_obs_only = TableModel.parse(
+        AnnData(X=X, obs=obs, var=pd.DataFrame(index=["G1", "G2"])),
+        region=["pts"],
+        region_key="region",
+        instance_key="instance_id",
+    )
+    sdata_obs_only = SpatialData(points={"pts": pts}, tables={"t": table_obs_only})
+    sdata_obs_only.pl.render_points("pts", color="GeneA", table_name="t").pl.show()
+
+
 def test_explicit_table_name_honored_when_element_has_same_column():
     # regression test for #620: explicit table_name= must not be silently
     # discarded when the element has a same-named column with different values.

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -423,21 +423,11 @@ def test_color_column_collision_on_annotating_table_raises():
 
 
 def test_color_key_obs_var_shadow_raises():
-    # regression test for #621: when the same key exists in both `table.obs.columns`
-    # and `table.var_names`, upstream `_get_table_origins` silently returns only the
-    # obs origin (elif chain). Surface the ambiguity at the plotting layer instead.
-    pts = PointsModel.parse(pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0], "y": [1.0, 2.0, 3.0, 4.0]}))
-    obs = pd.DataFrame(
-        {
-            "instance_id": [0, 1, 2, 3],
-            "region": ["pts"] * 4,
-            "GeneA": [0.9, 0.8, 0.7, 0.6],
-        }
-    )
-    obs.index = obs.index.astype(str)
-    X = np.array([[1.0, 0.5], [0.8, 0.2], [0.3, 0.9], [0.1, 0.7]])
+    # regression test for #621
+    pts = PointsModel.parse(pd.DataFrame({"x": [1.0, 2.0], "y": [1.0, 2.0]}))
+    obs = pd.DataFrame({"instance_id": [0, 1], "region": ["pts"] * 2, "GeneA": [0.9, 0.6]}, index=["0", "1"])
     table = TableModel.parse(
-        AnnData(X=X, obs=obs, var=pd.DataFrame(index=["GeneA", "GeneB"])),
+        AnnData(X=np.zeros((2, 1)), obs=obs, var=pd.DataFrame(index=["GeneA"])),
         region=["pts"],
         region_key="region",
         instance_key="instance_id",
@@ -446,30 +436,6 @@ def test_color_key_obs_var_shadow_raises():
 
     with pytest.raises(ValueError, match=r"'GeneA'.*ambiguous.*obs\.columns.*var_names"):
         sdata.pl.render_points("pts", color="GeneA", table_name="t").pl.show()
-
-    # Negative control: only in var → no error.
-    obs_var_only = pd.DataFrame(
-        {"instance_id": [0, 1, 2, 3], "region": ["pts"] * 4},
-        index=[str(i) for i in range(4)],
-    )
-    table_var_only = TableModel.parse(
-        AnnData(X=X, obs=obs_var_only, var=pd.DataFrame(index=["GeneA", "GeneB"])),
-        region=["pts"],
-        region_key="region",
-        instance_key="instance_id",
-    )
-    sdata_var_only = SpatialData(points={"pts": pts}, tables={"t": table_var_only})
-    sdata_var_only.pl.render_points("pts", color="GeneA", table_name="t").pl.show()
-
-    # Negative control: only in obs → no error.
-    table_obs_only = TableModel.parse(
-        AnnData(X=X, obs=obs, var=pd.DataFrame(index=["G1", "G2"])),
-        region=["pts"],
-        region_key="region",
-        instance_key="instance_id",
-    )
-    sdata_obs_only = SpatialData(points={"pts": pts}, tables={"t": table_obs_only})
-    sdata_obs_only.pl.render_points("pts", color="GeneA", table_name="t").pl.show()
 
 
 def test_explicit_table_name_honored_when_element_has_same_column():


### PR DESCRIPTION
## Summary
- Fix #621: when a key existed in both `table.obs.columns` and `table.var_names`, upstream `_get_table_origins`'s `elif` chain returned only the `obs` origin and the user silently got obs values instead of gene expression.
- Add `_check_obs_var_shadow` in `pl/utils.py`, called from `_render_shapes`/`_render_points`/`_render_labels` before any value fetch (the table's `var_names` are clobbered later in the rendering pipeline, so the check must run early).
- Raise a descriptive `ValueError` naming both `obs.columns` and `var_names` and pointing at the table key, so the user can rename or drop one side.
