### PR TITLE
perf(labels): compute np.unique(label) once per render

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -2111,11 +2111,15 @@ def _render_labels(
         # the above adds a useless c dimension of 1 (y, x) -> (1, y, x)
         label = label.squeeze()
 
+    # Unique label values are needed for the instance ids, the overlap check, and the
+    # rasterize mask below; compute them once over the (possibly rasterized) raster.
+    unique_labels = np.unique(label.values)
+
     if table_name is None:
-        instance_id = np.unique(label)
+        instance_id = unique_labels
         table = None
     else:
-        _check_instance_ids_overlap(sdata_filt, table_name, element, np.unique(label.values))
+        _check_instance_ids_overlap(sdata_filt, table_name, element, unique_labels)
         _, region_key, instance_key = get_table_keys(sdata[table_name])
         table = sdata[table_name][sdata[table_name].obs[region_key].isin([element])]
 
@@ -2185,8 +2189,7 @@ def _render_labels(
     # rasterize could have removed labels from label
     # only problematic if color is specified
     if rasterize and (col_for_color is not None or col_for_outline_color is not None):
-        labels_in_rasterized_image = np.unique(label.values)
-        mask = np.isin(instance_id, labels_in_rasterized_image)
+        mask = np.isin(instance_id, unique_labels)
         instance_id = instance_id[mask]
         if col_for_color is not None:
             color_vector = color_vector[mask]


### PR DESCRIPTION
## What & why

Third item from the profiling write-up in #690 (after #691 shapes and #692 points).

`_render_labels` uniquified the (already-rasterized) label raster up to twice per render:

- once for the instance ids (`np.unique(label)`) or, when a table annotates the element,
  the overlap check (`np.unique(label.values)`);
- again for the rasterize mask (`labels_in_rasterized_image = np.unique(label.values)`).

Both run on the same array, so the second pass is redundant.

## Change

Compute the unique label values once after the (optional) rasterization, and reuse them
for the instance ids, the overlap check, and the rasterize mask.

## Correctness — byte-identical output

Rendered 8 label scenarios on this branch and on `main`, comparing the Agg RGBA buffers
exactly (`np.array_equal`): **all identical**.

> plain · contour · continuous · continuous fill+outline · categorical · `groups` ·
> `groups`+`na_color` · outline-only

This covers both the no-table path (instance ids from the raster) and the
table-annotated path (overlap check + rasterize mask).

## Performance

Removes one full-raster `np.unique` pass per render. The saving scales with the
displayed/rasterized label size (the label is downsampled to the canvas by default):

| render | main | this PR |
|--------|------|---------|
| 2000-px label, figsize 4×4, dpi 100 | ~289 ms | ~284 ms (~5 ms) |
| 2000-px label, figsize 12×12, dpi 300 | ~2336 ms | ~2296 ms (~40 ms) |

Small at default settings, larger for high-resolution / large-figure renders. It's a
correctness-neutral cleanup that also removes a redundant local variable.