### PR TITLE
ci: bump codecov-action to v6 to fix signature verification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
           path: tests/figures/*
       - name: Upload coverage
         if: matrix.env.name == 'hatch-test.py3.14-stable'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
           use_oidc: true


### PR DESCRIPTION
`codecov-action@v5` verifies the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts. The upload step now fails with `Could not verify signature`, and because `fail_ci_if_error: true` this hard-fails the Coverage job on every PR.

`@v6` (= 6.0.2) ships the updated key. One-line pin bump.

Ref: https://github.com/codecov/codecov-action/issues/1956