### PR TITLE
perf(images): materialize rasterized image once to avoid per-channel re-warp

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -2283,6 +2283,10 @@ def _rasterize_if_necessary(
             coordinate_system,
             target_unit_to_pixels=target_unit_to_pixels,
         )
+        if hasattr(image.data, "compute"):
+            # rasterize is lazy; downstream reads the result once per channel (NaN check,
+            # compositing, draw), so materialize once instead of re-running the warp each time.
+            image = image.copy(data=image.data.compute())
 
     return image
 


### PR DESCRIPTION
## What

`render_images` re-materializes the lazy rasterized image **once per channel, on every pass**, so the affine warp runs `N_passes × N_channels` times per render. This materializes it once.

## Root cause

`spatialdata.rasterize` returns a **lazy** dask array (~5 ms). `_render_images` then reads it per channel in several passes — the NaN check, the per-channel compositing (`img.sel(c=ch).values`), and the draw — each of which recomputes the entire dask graph (the `order=0` affine warp + `concatenate3`). So an 8-channel render pays for the warp roughly `passes × 8` times.

Measured (synthetic 8ch float32, chunked like the real pipeline):

| step | time |
|---|---|
| `_rasterize_if_necessary` (lazy) | 5 ms |
| full `pl.show` (8ch 6000²) | 10 245 ms |
| per-channel `.sel(c=ch).values` | 2544 ms |
| single `.compute()` of the same array | 320 ms (**8.0× = channel count**) |

## Fix

Materialize the rasterized array once before returning:

```python
image = rasterize(...)
if hasattr(image.data, "compute"):
    image = image.copy(data=image.data.compute())
```

## Results

End-to-end: **10 457 ms → 508 ms (20.6×)** at 8ch 6000²; **15.4×** at 4000². Single-channel is neutral. The datashader path already `.compute()`s, so it is unaffected.

## Why this is safe

- **Pixel-identical** output (`np.array_equal == True`) — transform, coords, and channel labels preserved — so **no visual baselines change** (that's the correctness proof: existing image/label tests stay green unchanged).
- **Memory-bounded**: the output of `_rasterize_if_necessary` is always display-sized (rasterized to ~target, or returned only when ≤ target+100 per axis), so the eager compute is ~15 MB at 700²×8.
- Covers **images and labels** (both call `_rasterize_if_necessary`).

Closes #707.
