### PR TITLE
perf(shapes): drop the per-render table join when coloring by a table column

### DIFF
--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -600,8 +600,8 @@ def _render_shapes(
 
     _check_obs_var_shadow(sdata, element, col_for_color, render_params.table_name)
 
-    # filter_tables=False: join_spatialelement_table below overwrites the table,
-    # so the cs-level sparse copy is wasted work.
+    # filter_tables=False: the annotating table is read directly below (color is resolved per shape
+    # from it, region-masked and reindexed), so the cs-level sparse table copy would be wasted work.
     sdata_filt = sdata.filter_by_coordinate_system(
         coordinate_system=coordinate_system,
         filter_tables=False,
@@ -610,12 +610,11 @@ def _render_shapes(
     table_name = render_params.table_name
     if table_name is None:
         table = None
-        shapes = sdata_filt[element]
     else:
+        # No join/copy: _set_color_source_vec resolves each shape's color from the table (region-masked
+        # and reindexed to the element), so unannotated shapes keep their place and render with na_color.
         _check_instance_ids_overlap(sdata_filt, table_name, element, sdata_filt[element].index)
-        joined_element, joined_table = _join_table_for_element(sdata, element, table_name)
-        sdata_filt[element] = shapes = joined_element
-        sdata_filt[table_name] = table = joined_table
+        table = sdata_filt[table_name]
 
     shapes = sdata_filt[element]
 


### PR DESCRIPTION
## What

`_render_shapes` colored by a table column joined the element to its annotating table via `_join_table_for_element`, whose `table[joined_indices, :].copy()` does an **out-of-order sparse CSR row-gather copy of the whole AnnData** every render. This drops that join — the original element + table are used directly.

This is the structural follow-up ("Phase 2") to #709 (the color re-join) and #711 (na_color for unannotated). After those landed, the joined element/table are no longer needed.

## Why it's safe (no behavior change)

- **Color** is resolved per shape by `_extract_color_column` (#709), which **region-masks and reindexes the table itself** — it never needed the table pre-joined.
- **`how="left"` (#711)** already keeps all shapes with na_color for unannotated, in the element's original order — so dropping the join (which equally keeps all shapes in original order) renders the same thing.
- **Audit of every `table`/`adata` consumer**: the matplotlib and datashader draw paths never touch the table; `_decorate_axs`'s `adata` is a dead parameter; `.uns["{col}_colors"]` custom colors are read from `sdata[table_name]` inside `_set_color_source_vec`, not the passed object. Nothing requires the joined/region-filtered table.
- **Verified pixel-identical** to the join path across partial-annotation/na_color, fully-annotated, real datashader (curio, 69k circles, categorical), and real Visium (gene) — so **existing visual baselines are unchanged**.
- 119 non-visual shapes/utils tests pass.

## Result

`visium_hne render_shapes(color=gene)`: **451 ms → 297 ms (1.52×)**. The saving is the eliminated table copy and scales with table width (larger for Xenium / Visium-HD-width tables). datashader-dominated renders (e.g. curio) see little change because the copy is a small fraction of their cost.

## Scope

Fill path only — the **outline** path keeps its own (rarer) `_join_table_for_element` (separate outline table + its own length-alignment logic); converting it is a small separate follow-up. `_join_table_for_element` itself is unchanged (still used by the outline path).
