### PR TITLE
test: cap matplotlib<3.11 to stabilize colorbar image baselines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dev = [
 ]
 test = [
   "coverage[toml]>=7.4",
+  # Image-comparison baselines are matplotlib-version-sensitive; matplotlib 3.11.0 (released
+  # 2026-06-12) shifts colorbar rendering past the comparison tolerance. Cap for tests only
+  # (the runtime dependency stays open) until the baselines are regenerated against 3.11.
+  "matplotlib<3.11",
   "pooch",
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
## Problem
`matplotlib==3.11.0` was released on 2026-06-12 (02:27 UTC) and changes colorbar/image rasterization enough to push `tests/pl/test_colorbar.py::TestColorbarControls` image comparisons past the RMS tolerance (RMS ~22–31 vs tol 15). This fails CI **repo-wide** on the `hatch-test.py3.11-stable` env — `main` and every open PR will go red on their next run once `uv` resolves 3.11.0. (`py3.14-stable` is unaffected for now: 3.11.0 ships no cp314 wheel yet, so that env stays on 3.10.x.)

Confirmed via PyPI upload timestamp: the last passing run resolved 3.10.x (run before 3.11.0 existed), the first failing run resolved 3.11.0. No source change is involved.

## Fix
Cap `matplotlib<3.11` in the **`test` dependency-group only**. CI's `hatch-test` env installs that group, so the cap applies to testing; the package's runtime `matplotlib` dependency stays open, so users and downstream libraries still resolve 3.11.

## Follow-up
Temporary. The proper fix is to regenerate the `test_colorbar` baselines against matplotlib 3.11 and lift the cap; the inline comment flags that.