### PR TITLE
refactor(color): ColorSpec - typed color-state boundary

### DIFF
--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -17,7 +17,6 @@ from geopandas import GeoDataFrame
 from matplotlib import colors, rcParams
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import (
-    ColorConverter,
     Colormap,
     LinearSegmentedColormap,
     ListedColormap,
@@ -727,10 +726,10 @@ class ColorSpec:
         via norm+cmap with NaN/non-finite rows painted ``na_color``; an object vector mixes the two.
         """
         if self.source_vector is not None:  # categorical or none: color_vector holds per-row hex
-            return np.asarray(ColorConverter().to_rgba_array(list(self.color_vector)))
+            return np.asarray(colors.to_rgba_array(list(self.color_vector)))
         arr = np.asarray(self.color_vector)
         if arr.ndim == 2 and arr.shape[1] in (3, 4) and np.issubdtype(arr.dtype, np.number):
-            return np.asarray(ColorConverter().to_rgba_array(arr))
+            return np.asarray(colors.to_rgba_array(arr))
         rgba = np.empty((len(arr), 4), dtype=float)
         rgba[:] = colors.to_rgba(cmap_params.na_color.get_hex_with_alpha())
         if np.issubdtype(arr.dtype, np.number):
@@ -748,7 +747,7 @@ class ColorSpec:
             rgba[is_num] = cmap_params.cmap(norm(num[is_num]))
         color_mask = (~is_num) & series.notna().to_numpy()
         if color_mask.any():
-            rgba[color_mask] = ColorConverter().to_rgba_array(series[color_mask].tolist())
+            rgba[color_mask] = colors.to_rgba_array(series[color_mask].tolist())
         return rgba
 
     def align_to_length(self, n: int, na_color: Color) -> ColorSpec:

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -702,6 +702,20 @@ class ColorSpec:
             return replace(self, color_vector=transfunc(self.color_vector))
         return self
 
+    def with_color_vector(self, color_vector: ArrayLike) -> ColorSpec:
+        """Return a copy with a replaced ``color_vector`` (a post-resolution rewrite: reprocess, compute)."""
+        return replace(self, color_vector=color_vector)
+
+    def with_source_vector(self, source_vector: ArrayLike | pd.Series | None) -> ColorSpec:
+        """Return a copy with a replaced ``source_vector`` (e.g. ``remove_unused_categories``, ``compute``)."""
+        return replace(self, source_vector=source_vector)
+
+    def make_palette(self) -> ListedColormap:
+        """Build a ``ListedColormap`` from the colors, dropping NaN categories when categorical."""
+        if self.source_vector is None:
+            return ListedColormap(dict.fromkeys(self.color_vector))
+        return ListedColormap(dict.fromkeys(self.color_vector[~pd.Categorical(self.source_vector).isnull()]))
+
     def groups_keep_mask(self, groups: Any, na_color: Color) -> Any | None:
         """Rows whose category is in ``groups``, or None when the groups filter does not apply.
 

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -21,6 +21,7 @@ from matplotlib.colors import (
     Colormap,
     LinearSegmentedColormap,
     ListedColormap,
+    LogNorm,
     Normalize,
     to_rgba,
 )
@@ -130,58 +131,14 @@ def _resolve_continuous_norm(values: Any, cmap_params: CmapParams) -> Normalize:
             vmin = data_min
         if vmax is None:
             vmax = data_max
+    if vmin == vmax and not isinstance(base, LogNorm):
+        # A constant/degenerate range collapses the colormap onto its floor; fall back to the
+        # unit interval so the single value maps to a stable color. LogNorm is exempt: 0 is
+        # out of its domain.
+        vmin, vmax = 0.0, 1.0
     resolved = copy(base)
     resolved.vmin, resolved.vmax = vmin, vmax
     return resolved
-
-
-def _apply_mask_to_outline_vectors(
-    outline_color_vector: Any,
-    outline_color_source_vector: pd.Series | None,
-    mask: Any,
-) -> tuple[Any, pd.Series | None]:
-    """Apply a boolean ``keep`` mask to outline color vector(s).
-
-    Used to keep outline data aligned with the fill data after a ``groups``
-    or rasterize-based filter is applied to the rendered element.
-    """
-    arr = np.asarray(mask)
-    if outline_color_source_vector is not None:
-        outline_color_source_vector = outline_color_source_vector[arr]
-    return outline_color_vector[arr], outline_color_source_vector
-
-
-def _align_outline_vector_to_length(
-    outline_color_vector: Any,
-    outline_color_source_vector: pd.Series | None,
-    n: int,
-) -> tuple[Any, pd.Series | None]:
-    """Pad or truncate the outline color vector(s) to length ``n``.
-
-    Used when the outline column annotates a different row count than the rendered
-    element (cross-table case, or rasterize-induced label drop). Missing entries
-    are padded with NaN so downstream code maps them to ``na_color``.
-    """
-    if outline_color_vector is None or len(outline_color_vector) == n:
-        return outline_color_vector, outline_color_source_vector
-    if len(outline_color_vector) > n:
-        if outline_color_source_vector is not None:
-            outline_color_source_vector = outline_color_source_vector[:n]
-        return outline_color_vector[:n], outline_color_source_vector
-    pad = n - len(outline_color_vector)
-    if outline_color_source_vector is not None:
-        # Categorical: downstream picks one hex per category from rows that *have* a
-        # category. NaN-padded rows contribute no category, so the per-row hex pad is
-        # immaterial; pad with NaN to skip the allocation.
-        padded_vec = np.concatenate([np.asarray(outline_color_vector), np.full(pad, np.nan, dtype=object)])
-        outline_color_source_vector = pd.Categorical(
-            list(outline_color_source_vector) + [None] * pad,
-            categories=outline_color_source_vector.categories,
-        )
-    else:
-        # Continuous: numeric vector, pad with NaN so cmap maps padded rows to na_color.
-        padded_vec = np.concatenate([np.asarray(outline_color_vector, dtype=float), np.full(pad, np.nan)])
-    return padded_vec, outline_color_source_vector
 
 
 def _color_vector_to_rgba(
@@ -742,7 +699,7 @@ def _set_color_source_vec(
 ColorType = Literal["categorical", "continuous", "none"]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class ColorSpec:
     """Resolved color for one element layer: the explicit color-state the renderers consume.
 
@@ -793,13 +750,32 @@ class ColorSpec:
             return replace(self, color_vector=transfunc(self.color_vector))
         return self
 
-    def with_color_vector(self, color_vector: ArrayLike) -> ColorSpec:
-        """Return a copy with a replaced ``color_vector`` (renderer-specific rewrites: broadcast, compute)."""
-        return replace(self, color_vector=color_vector)
+    def align_to_length(self, n: int, na_color: Color) -> ColorSpec:
+        """Pad or truncate both vectors to ``n`` rows (cross-table / rasterize outline alignment).
+
+        Padded rows render as ``na_color``: a categorical (hex) ``color_vector`` pads with the na_color
+        hex — NaN would crash ``to_rgba_array`` — and ``source_vector`` with an absent category; a
+        continuous vector pads with NaN so the cmap maps it to na_color.
+        """
+        vec = self.color_vector
+        if vec is None or len(vec) == n:
+            return self
+        if len(vec) > n:
+            source = None if self.source_vector is None else self.source_vector[:n]
+            return replace(self, source_vector=source, color_vector=np.asarray(vec)[:n])
+        pad = n - len(vec)
+        if self.source_vector is not None:
+            padded = np.concatenate(
+                [np.asarray(vec, dtype=object), np.full(pad, na_color.get_hex_with_alpha(), dtype=object)]
+            )
+            source = pd.Categorical(list(self.source_vector) + [None] * pad, categories=self.source_vector.categories)
+            return replace(self, source_vector=source, color_vector=padded)
+        padded = np.concatenate([np.asarray(vec, dtype=float), np.full(pad, np.nan)])
+        return replace(self, color_vector=padded)
 
 
 def resolve_color(*args: Any, **kwargs: Any) -> ColorSpec:
-    """Resolve an element's color into a typed :class:`ColorSpec` (the #700 IR's color layer).
+    """Resolve an element's color into a typed :class:`ColorSpec`.
 
     Pass-through wrapper over :func:`_set_color_source_vec` that classifies its result into an
     explicit ``colortype`` so callers stop re-deriving the state from ``source is None``/``categorical``.

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from copy import copy
+from dataclasses import dataclass
 from typing import Any, Literal
 
 import matplotlib
@@ -734,6 +735,40 @@ def _set_color_source_vec(
     raise KeyError(
         f"Unable to locate color key '{value_to_plot}' in table '{table_name}' for element '{element_name}'."
     )
+
+
+ColorType = Literal["categorical", "continuous", "none"]
+
+
+@dataclass(frozen=True)
+class ColorSpec:
+    """Resolved color for one element layer: the explicit color-state the renderers consume.
+
+    ``colortype`` names the three states the renderers used to infer implicitly from
+    ``source_vector``/``categorical``: ``categorical`` (``source_vector`` is the Categorical),
+    ``continuous`` (``source_vector`` is None, ``color_vector`` is numeric), ``none`` (no/uncolorable
+    value -> ``color_vector`` is the na_color, ``source_vector`` is a non-None na array).
+    """
+
+    colortype: ColorType
+    source_vector: ArrayLike | pd.Series | None
+    color_vector: ArrayLike
+
+
+def resolve_color(*args: Any, **kwargs: Any) -> ColorSpec:
+    """Resolve an element's color into a typed :class:`ColorSpec` (the #700 IR's color layer).
+
+    Pass-through wrapper over :func:`_set_color_source_vec` that classifies its result into an
+    explicit ``colortype`` so callers stop re-deriving the state from ``source is None``/``categorical``.
+    """
+    source_vector, color_vector, categorical = _set_color_source_vec(*args, **kwargs)
+    if categorical:
+        colortype: ColorType = "categorical"
+    elif source_vector is None:
+        colortype = "continuous"
+    else:
+        colortype = "none"
+    return ColorSpec(colortype=colortype, source_vector=source_vector, color_vector=color_vector)
 
 
 def _map_color_seg(

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -702,13 +702,9 @@ class ColorSpec:
             return replace(self, color_vector=transfunc(self.color_vector))
         return self
 
-    def with_color_vector(self, color_vector: ArrayLike) -> ColorSpec:
-        """Return a copy with a replaced ``color_vector`` (a post-resolution rewrite: reprocess, compute)."""
-        return replace(self, color_vector=color_vector)
-
-    def with_source_vector(self, source_vector: ArrayLike | pd.Series | None) -> ColorSpec:
-        """Return a copy with a replaced ``source_vector`` (e.g. ``remove_unused_categories``, ``compute``)."""
-        return replace(self, source_vector=source_vector)
+    def evolve(self, **changes: Any) -> ColorSpec:
+        """Return a copy with ``source_vector``/``color_vector`` replaced (post-resolution rewrites)."""
+        return replace(self, **changes)
 
     def make_palette(self) -> ListedColormap:
         """Build a ``ListedColormap`` from the colors, dropping NaN categories when categorical."""
@@ -734,14 +730,13 @@ class ColorSpec:
         Categorical/none ``color_vector`` is per-row hex -> straight to RGBA; continuous numerics map
         via norm+cmap with NaN/non-finite rows painted ``na_color``; an object vector mixes the two.
         """
-        na_rgba = colors.to_rgba(cmap_params.na_color.get_hex_with_alpha())
         if self.source_vector is not None:  # categorical or none: color_vector holds per-row hex
             return np.asarray(ColorConverter().to_rgba_array(list(self.color_vector)))
         arr = np.asarray(self.color_vector)
         if arr.ndim == 2 and arr.shape[1] in (3, 4) and np.issubdtype(arr.dtype, np.number):
             return np.asarray(ColorConverter().to_rgba_array(arr))
         rgba = np.empty((len(arr), 4), dtype=float)
-        rgba[:] = na_rgba
+        rgba[:] = colors.to_rgba(cmap_params.na_color.get_hex_with_alpha())
         if np.issubdtype(arr.dtype, np.number):
             finite = np.isfinite(arr)
             if finite.any():

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -105,13 +105,9 @@ def _is_color_like(color: Any) -> bool:
 
 
 def _make_continuous_mappable(vmin: float, vmax: float, cmap: Any) -> ScalarMappable:
-    """Build a ``ScalarMappable`` for a continuous colorbar.
-
-    A degenerate ``vmin == vmax`` falls back to ``[0, 1]`` — the same rule as
-    :func:`_resolve_continuous_norm`, so the colorbar agrees with the pixel mapping.
-    """
+    """Build a ``ScalarMappable`` for a continuous colorbar, with a ±0.5 fallback when ``vmin == vmax``."""
     if vmin == vmax:
-        vmin, vmax = 0.0, 1.0
+        vmin, vmax = vmin - 0.5, vmax + 0.5
     return ScalarMappable(norm=Normalize(vmin=vmin, vmax=vmax), cmap=cmap)
 
 

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -132,9 +132,7 @@ def _resolve_continuous_norm(values: Any, cmap_params: CmapParams) -> Normalize:
         if vmax is None:
             vmax = data_max
     if vmin == vmax and not isinstance(base, LogNorm):
-        # A constant/degenerate range collapses the colormap onto its floor; fall back to the
-        # unit interval so the single value maps to a stable color. LogNorm is exempt: 0 is
-        # out of its domain.
+        # degenerate range collapses the cmap onto its floor; fall back to [0, 1]. LogNorm exempt (0 not in domain).
         vmin, vmax = 0.0, 1.0
     resolved = copy(base)
     resolved.vmin, resolved.vmax = vmin, vmax
@@ -701,20 +699,19 @@ ColorType = Literal["categorical", "continuous", "none"]
 
 @dataclass(frozen=True, eq=False)
 class ColorSpec:
-    """Resolved color for one element layer: the explicit color-state the renderers consume.
+    """Resolved color for one element layer, with the color-state made explicit.
 
-    ``colortype`` names the three states the renderers used to infer implicitly from
-    ``source_vector``/``categorical``: ``categorical`` (``source_vector`` is the Categorical),
-    ``continuous`` (``source_vector`` is None, ``color_vector`` is numeric), ``none`` (no/uncolorable
-    value -> ``color_vector`` is the na_color, ``source_vector`` is a non-None na array).
+    ``colortype``: ``categorical`` (``source_vector`` is the Categorical), ``continuous``
+    (``source_vector`` is None, ``color_vector`` numeric), ``none`` (uncolorable -> ``color_vector`` is
+    na_color, ``source_vector`` a non-None na array). Trap: ``source_vector is not None`` means
+    categorical OR none, not categorical — branch on :attr:`is_categorical`.
     """
 
     colortype: ColorType
     source_vector: ArrayLike | pd.Series | None
     color_vector: ArrayLike
 
-    # Predicates on the invariant ``colortype`` — safe to read anywhere (unlike the vectors, which
-    # the renderers mutate after resolution). They replace scattered, typo-prone ``colortype == "..."``.
+    # Predicates on the invariant ``colortype`` (the vectors get mutated after resolution; the type does not).
     @property
     def is_categorical(self) -> bool:
         return self.colortype == "categorical"
@@ -727,8 +724,7 @@ class ColorSpec:
     def is_none(self) -> bool:
         return self.colortype == "none"
 
-    # Immutable transforms — return a new spec so the renderers can thread one ``color_spec`` through
-    # the post-resolution mutations instead of reassigning two vectors in lockstep (the sync footgun).
+    # Immutable transforms: return a new spec so renderers thread one ``color_spec``, not two vectors in lockstep.
     def filter(self, mask: Any) -> ColorSpec:
         """Row-subset both vectors by a boolean/index ``mask``; ``colortype`` is unchanged.
 
@@ -753,25 +749,27 @@ class ColorSpec:
     def align_to_length(self, n: int, na_color: Color) -> ColorSpec:
         """Pad or truncate both vectors to ``n`` rows (cross-table / rasterize outline alignment).
 
-        Padded rows render as ``na_color``: a categorical (hex) ``color_vector`` pads with the na_color
-        hex — NaN would crash ``to_rgba_array`` — and ``source_vector`` with an absent category; a
-        continuous vector pads with NaN so the cmap maps it to na_color.
+        Padded rows render as ``na_color``: continuous pads with NaN; categorical/none pad the hex
+        ``color_vector`` with the na_color hex (NaN would crash ``to_rgba_array``) and the
+        ``source_vector`` with an absent category / na entry.
         """
         vec = self.color_vector
         if vec is None or len(vec) == n:
             return self
         if len(vec) > n:
             source = None if self.source_vector is None else self.source_vector[:n]
-            return replace(self, source_vector=source, color_vector=np.asarray(vec)[:n])
+            return replace(self, source_vector=source, color_vector=vec[:n])
         pad = n - len(vec)
-        if self.source_vector is not None:
-            padded = np.concatenate(
-                [np.asarray(vec, dtype=object), np.full(pad, na_color.get_hex_with_alpha(), dtype=object)]
-            )
+        if self.is_continuous:
+            padded = np.concatenate([np.asarray(vec, dtype=float), np.full(pad, np.nan)])
+            return replace(self, color_vector=padded)
+        na_hex = na_color.get_hex_with_alpha()
+        padded = np.concatenate([np.asarray(vec, dtype=object), np.full(pad, na_hex, dtype=object)])
+        if self.is_categorical:
             source = pd.Categorical(list(self.source_vector) + [None] * pad, categories=self.source_vector.categories)
-            return replace(self, source_vector=source, color_vector=padded)
-        padded = np.concatenate([np.asarray(vec, dtype=float), np.full(pad, np.nan)])
-        return replace(self, color_vector=padded)
+        else:  # none: source is an na array, not a Categorical — extend it with na entries
+            source = np.concatenate([np.asarray(self.source_vector, dtype=object), np.full(pad, na_hex, dtype=object)])
+        return replace(self, source_vector=source, color_vector=padded)
 
 
 def resolve_color(*args: Any, **kwargs: Any) -> ColorSpec:

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from copy import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal
 
 import matplotlib
@@ -767,6 +767,33 @@ class ColorSpec:
     @property
     def is_none(self) -> bool:
         return self.colortype == "none"
+
+    # Immutable transforms — return a new spec so the renderers can thread one ``color_spec`` through
+    # the post-resolution mutations instead of reassigning two vectors in lockstep (the sync footgun).
+    def filter(self, mask: Any) -> ColorSpec:
+        """Row-subset both vectors by a boolean/index ``mask``; ``colortype`` is unchanged.
+
+        A categorical ``color_vector`` keeps its dtype and drops now-unused categories; otherwise it is
+        coerced to an array (matching the groups/transparent-na path). ``source_vector`` (None for
+        continuous) is masked as-is.
+        """
+        source = None if self.source_vector is None else self.source_vector[mask]
+        color = self.color_vector
+        if isinstance(getattr(color, "dtype", None), pd.CategoricalDtype):
+            color = color[mask].remove_unused_categories()
+        else:
+            color = np.asarray(color)[mask]
+        return replace(self, source_vector=source, color_vector=color)
+
+    def apply_transfunc(self, transfunc: Any) -> ColorSpec:
+        """Map ``color_vector`` through ``transfunc`` for continuous coloring; no-op otherwise."""
+        if self.is_continuous and transfunc is not None:
+            return replace(self, color_vector=transfunc(self.color_vector))
+        return self
+
+    def with_color_vector(self, color_vector: ArrayLike) -> ColorSpec:
+        """Return a copy with a replaced ``color_vector`` (renderer-specific rewrites: broadcast, compute)."""
+        return replace(self, color_vector=color_vector)
 
 
 def resolve_color(*args: Any, **kwargs: Any) -> ColorSpec:

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -698,6 +698,18 @@ class ColorSpec:
             return replace(self, color_vector=transfunc(self.color_vector))
         return self
 
+    def groups_keep_mask(self, groups: Any, na_color: Color) -> Any | None:
+        """Rows whose category is in ``groups``, or None when the groups filter does not apply.
+
+        Does not apply when there is no ``groups``, the layer is not categorical, or ``na_color`` is a
+        visible override (which shows non-matching rows rather than dropping them).
+        """
+        if groups is None or not self.is_categorical:
+            return None
+        if not (na_color.default_color_set or na_color.is_fully_transparent()):
+            return None
+        return self.source_vector.isin(groups)
+
     def to_rgba(self, cmap_params: CmapParams) -> np.ndarray:
         """Map this layer's color to an ``(N, 4)`` RGBA array; the one fill+outline mapping.
 

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -139,54 +139,6 @@ def _resolve_continuous_norm(values: Any, cmap_params: CmapParams) -> Normalize:
     return resolved
 
 
-def _color_vector_to_rgba(
-    color_vector: Any | None,
-    color_source_vector: pd.Series | None,
-    cmap_params: CmapParams,
-    n_rows: int,
-) -> np.ndarray:
-    """Convert a fill/outline `color_vector` (categorical hex strings or continuous numerics) to (N, 4) RGBA.
-
-    Mirrors the per-row mapping done inside :func:`_get_collection_shape` so that
-    callers can pre-materialize an outline-color array. NaN/non-finite entries are
-    painted with ``cmap_params.na_color``.
-    """
-    na_rgba = colors.to_rgba(cmap_params.na_color.get_hex_with_alpha())
-    if color_vector is None:
-        rgba = np.empty((n_rows, 4), dtype=float)
-        rgba[:] = na_rgba
-        return rgba
-
-    if color_source_vector is not None:
-        # Categorical: color_vector contains hex strings aligned to color_source_vector
-        return np.asarray(ColorConverter().to_rgba_array(list(color_vector)))
-
-    arr = np.asarray(color_vector)
-    if arr.ndim == 2 and arr.shape[1] in (3, 4) and np.issubdtype(arr.dtype, np.number):
-        return np.asarray(ColorConverter().to_rgba_array(arr))
-
-    rgba = np.empty((len(arr), 4), dtype=float)
-    rgba[:] = na_rgba
-    if np.issubdtype(arr.dtype, np.number):
-        finite_mask = np.isfinite(arr)
-        if finite_mask.any():
-            used_norm = _resolve_continuous_norm(arr, cmap_params)
-            rgba[finite_mask] = cmap_params.cmap(used_norm(arr[finite_mask]))
-        return rgba
-
-    # Object dtype: mix of numerics and color-like specs (apply cmap to the numeric subset only)
-    series = pd.Series(arr, copy=False)
-    num = pd.to_numeric(series, errors="coerce").to_numpy()
-    is_num = np.isfinite(num)
-    if is_num.any():
-        used_norm = _resolve_continuous_norm(num, cmap_params)
-        rgba[is_num] = cmap_params.cmap(used_norm(num[is_num]))
-    color_mask = (~is_num) & series.notna().to_numpy()
-    if color_mask.any():
-        rgba[color_mask] = ColorConverter().to_rgba_array(series[color_mask].tolist())
-    return rgba
-
-
 def _prepare_cmap_norm(
     cmap: Colormap | str | None = None,
     norm: Normalize | None = None,
@@ -745,6 +697,38 @@ class ColorSpec:
         if self.is_continuous and transfunc is not None:
             return replace(self, color_vector=transfunc(self.color_vector))
         return self
+
+    def to_rgba(self, cmap_params: CmapParams) -> np.ndarray:
+        """Map this layer's color to an ``(N, 4)`` RGBA array; the one fill+outline mapping.
+
+        Categorical/none ``color_vector`` is per-row hex -> straight to RGBA; continuous numerics map
+        via norm+cmap with NaN/non-finite rows painted ``na_color``; an object vector mixes the two.
+        """
+        na_rgba = colors.to_rgba(cmap_params.na_color.get_hex_with_alpha())
+        if self.source_vector is not None:  # categorical or none: color_vector holds per-row hex
+            return np.asarray(ColorConverter().to_rgba_array(list(self.color_vector)))
+        arr = np.asarray(self.color_vector)
+        if arr.ndim == 2 and arr.shape[1] in (3, 4) and np.issubdtype(arr.dtype, np.number):
+            return np.asarray(ColorConverter().to_rgba_array(arr))
+        rgba = np.empty((len(arr), 4), dtype=float)
+        rgba[:] = na_rgba
+        if np.issubdtype(arr.dtype, np.number):
+            finite = np.isfinite(arr)
+            if finite.any():
+                norm = _resolve_continuous_norm(arr, cmap_params)
+                rgba[finite] = cmap_params.cmap(norm(arr[finite]))
+            return rgba
+        # object dtype: numeric subset via cmap(norm), explicit color-likes via to_rgba_array
+        series = pd.Series(arr, copy=False)
+        num = pd.to_numeric(series, errors="coerce").to_numpy()
+        is_num = np.isfinite(num)
+        if is_num.any():
+            norm = _resolve_continuous_norm(num, cmap_params)
+            rgba[is_num] = cmap_params.cmap(norm(num[is_num]))
+        color_mask = (~is_num) & series.notna().to_numpy()
+        if color_mask.any():
+            rgba[color_mask] = ColorConverter().to_rgba_array(series[color_mask].tolist())
+        return rgba
 
     def align_to_length(self, n: int, na_color: Color) -> ColorSpec:
         """Pad or truncate both vectors to ``n`` rows (cross-table / rasterize outline alignment).

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -105,9 +105,13 @@ def _is_color_like(color: Any) -> bool:
 
 
 def _make_continuous_mappable(vmin: float, vmax: float, cmap: Any) -> ScalarMappable:
-    """Build a ``ScalarMappable`` for a continuous colorbar, with a ±0.5 fallback when ``vmin == vmax``."""
+    """Build a ``ScalarMappable`` for a continuous colorbar.
+
+    A degenerate ``vmin == vmax`` falls back to ``[0, 1]`` — the same rule as
+    :func:`_resolve_continuous_norm`, so the colorbar agrees with the pixel mapping.
+    """
     if vmin == vmax:
-        vmin, vmax = vmin - 0.5, vmax + 0.5
+        vmin, vmax = 0.0, 1.0
     return ScalarMappable(norm=Normalize(vmin=vmin, vmax=vmax), cmap=cmap)
 
 

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -754,6 +754,20 @@ class ColorSpec:
     source_vector: ArrayLike | pd.Series | None
     color_vector: ArrayLike
 
+    # Predicates on the invariant ``colortype`` — safe to read anywhere (unlike the vectors, which
+    # the renderers mutate after resolution). They replace scattered, typo-prone ``colortype == "..."``.
+    @property
+    def is_categorical(self) -> bool:
+        return self.colortype == "categorical"
+
+    @property
+    def is_continuous(self) -> bool:
+        return self.colortype == "continuous"
+
+    @property
+    def is_none(self) -> bool:
+        return self.colortype == "none"
+
 
 def resolve_color(*args: Any, **kwargs: Any) -> ColorSpec:
     """Resolve an element's color into a typed :class:`ColorSpec` (the #700 IR's color layer).

--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -111,11 +111,11 @@ def _make_continuous_mappable(vmin: float, vmax: float, cmap: Any) -> ScalarMapp
 
 
 def _resolve_continuous_norm(values: Any, cmap_params: CmapParams) -> Normalize:
-    """Resolve a concrete ``Normalize`` for continuous coloring.
+    """Resolve ``cmap_params.norm`` with concrete vmin/vmax for continuous coloring.
 
     Honor explicit ``norm`` vmin/vmax, else the finite-value data range of ``values``, else
-    ``[0, 1]``. Shared by the pixel and colorbar sites so both derive the same range. A degenerate
-    ``vmin == vmax`` is left as-is (matplotlib expands it downstream), not reset to ``[0, 1]``.
+    ``[0, 1]``. Shared by the pixel and colorbar sites so both derive the same range. Preserves the
+    norm subclass (``LogNorm``/``PowerNorm``/...) so non-linear scaling is not silently linearized.
     """
     base = cmap_params.norm
     vmin, vmax = base.vmin, base.vmax
@@ -130,7 +130,9 @@ def _resolve_continuous_norm(values: Any, cmap_params: CmapParams) -> Normalize:
             vmin = data_min
         if vmax is None:
             vmax = data_max
-    return Normalize(vmin=vmin, vmax=vmax, clip=base.clip)
+    resolved = copy(base)
+    resolved.vmin, resolved.vmax = vmin, vmax
+    return resolved
 
 
 def _apply_mask_to_outline_vectors(

--- a/src/spatialdata_plot/pl/_geometry.py
+++ b/src/spatialdata_plot/pl/_geometry.py
@@ -180,16 +180,12 @@ def _get_collection_shape(
     color / list of color specs (broadcast). ``outline_color`` may be an ``(N, 4)`` float RGBA array,
     whose alpha channel is mutated in place to apply ``outline_alpha`` (pass a copy to retain it).
     """
-    # Per-row fill is pre-mapped to RGBA by ``ColorSpec.to_rgba``; here ``c`` is either that
-    # (N, 4) array or a single color / list of color specs (e.g. the white outline placeholder).
+    # Per-row fill is pre-mapped to RGBA by ``ColorSpec.to_rgba`` (an (N, 4) float array, used
+    # as-is); otherwise ``c`` is a single color / list of color specs (e.g. the white outline
+    # placeholder), which ``to_rgba_array`` broadcasts.
     c_arr = np.asarray(c)
-    if (
-        c_arr.ndim == 2
-        and c_arr.shape[0] == len(shapes)
-        and c_arr.shape[1] in (3, 4)
-        and np.issubdtype(c_arr.dtype, np.number)
-    ):
-        fill_c = np.asarray(ColorConverter().to_rgba_array(c_arr))
+    if c_arr.shape == (len(shapes), 4) and np.issubdtype(c_arr.dtype, np.floating):
+        fill_c = c_arr
     else:
         fill_c = np.asarray(ColorConverter().to_rgba_array(c))
 

--- a/src/spatialdata_plot/pl/_geometry.py
+++ b/src/spatialdata_plot/pl/_geometry.py
@@ -11,14 +11,12 @@ import numpy as np
 import pandas as pd
 import shapely
 from geopandas import GeoDataFrame
-from matplotlib import colors
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import ColorConverter
 from scipy.spatial import ConvexHull
 from shapely.errors import GEOSException
 
 from spatialdata_plot._logging import logger
-from spatialdata_plot.pl._color import _resolve_continuous_norm
 from spatialdata_plot.pl.render_params import ShapesRenderParams
 from spatialdata_plot.pl.utils import _extract_scalar_value
 
@@ -176,75 +174,24 @@ def _get_collection_shape(
     prebuilt_patches: tuple[list[mpatches.Patch], list[int], int] | None = None,
     **kwargs: Any,
 ) -> PatchCollection:
+    """Build a PatchCollection for shapes.
+
+    ``c`` is the per-row fill: an ``(N, 4)`` RGBA array (from :meth:`ColorSpec.to_rgba`) or a single
+    color / list of color specs (broadcast). ``outline_color`` may be an ``(N, 4)`` float RGBA array,
+    whose alpha channel is mutated in place to apply ``outline_alpha`` (pass a copy to retain it).
     """
-    Build a PatchCollection for shapes with correct handling of.
-
-      - continuous numeric vectors with NaNs,
-      - per-row RGBA arrays,
-      - a single color or a list of color specs.
-
-    Only NaNs are painted with na_color; finite values are mapped via norm+cmap.
-
-    .. note::
-       When ``outline_color`` is passed as an ``(N, 4)`` RGBA array of dtype ``float``,
-       its alpha channel is mutated in place to apply ``outline_alpha``. Pass a copy
-       if you need to retain the original buffer.
-    """
-    cmap = kwargs["cmap"]
-
-    # Resolve na color once
-    na_rgba = colors.to_rgba(render_params.cmap_params.na_color.get_hex_with_alpha())
-
-    # Try to interpret c as numpy array
+    # Per-row fill is pre-mapped to RGBA by ``ColorSpec.to_rgba``; here ``c`` is either that
+    # (N, 4) array or a single color / list of color specs (e.g. the white outline placeholder).
     c_arr = np.asarray(c)
-    fill_c: np.ndarray
-
-    def _as_rgba_array(x: Any) -> np.ndarray:
-        return np.asarray(ColorConverter().to_rgba_array(x))
-
-    # Case A: per-row numeric colors given as Nx3 or Nx4 float array
     if (
         c_arr.ndim == 2
         and c_arr.shape[0] == len(shapes)
         and c_arr.shape[1] in (3, 4)
         and np.issubdtype(c_arr.dtype, np.number)
     ):
-        fill_c = _as_rgba_array(c_arr)
-
-    # Case B: continuous numeric vector len == n_shapes (possibly with NaNs)
-    elif c_arr.ndim == 1 and len(c_arr) == len(shapes) and np.issubdtype(c_arr.dtype, np.number):
-        finite_mask = np.isfinite(c_arr)
-
-        # Map finite values through cmap(norm(.)); NaNs get na_color.
-        fill_c = np.empty((len(c_arr), 4), dtype=float)
-        fill_c[:] = na_rgba
-        if finite_mask.any():
-            used_norm = _resolve_continuous_norm(c_arr, render_params.cmap_params)
-            fill_c[finite_mask] = cmap(used_norm(c_arr[finite_mask]))
-
-    elif c_arr.ndim == 1 and len(c_arr) == len(shapes) and c_arr.dtype == object:
-        # Split into numeric vs color-like
-        c_series = pd.Series(c_arr, copy=False)
-        num = pd.to_numeric(c_series, errors="coerce").to_numpy()
-        is_num = np.isfinite(num)
-
-        # init with na color
-        fill_c = np.empty((len(c_series), 4), dtype=float)
-        fill_c[:] = na_rgba
-
-        # numeric entries via cmap(norm)
-        if is_num.any():
-            used_norm = _resolve_continuous_norm(num, render_params.cmap_params)
-            fill_c[is_num] = cmap(used_norm(num[is_num]))
-
-        # non-numeric, non-NaN entries as explicit colors
-        non_numeric_color_mask = (~is_num) & c_series.notna().to_numpy()
-        if non_numeric_color_mask.any():
-            fill_c[non_numeric_color_mask] = ColorConverter().to_rgba_array(c_series[non_numeric_color_mask].tolist())
-
-    # Case C: single color or list of color-like specs (strings or tuples)
+        fill_c = np.asarray(ColorConverter().to_rgba_array(c_arr))
     else:
-        fill_c = _as_rgba_array(c)
+        fill_c = np.asarray(ColorConverter().to_rgba_array(c))
 
     # Apply optional fill alpha without destroying existing transparency
     if fill_alpha is not None:
@@ -259,7 +206,7 @@ def _get_collection_shape(
             # on the hot path; otherwise upcast to a fresh float buffer.
             outline_c_array = outline_arr if outline_arr.dtype == float else outline_arr.astype(float)
         else:
-            outline_c_array = _as_rgba_array(outline_color)
+            outline_c_array = np.asarray(ColorConverter().to_rgba_array(outline_color))
         outline_c_array[..., -1] = outline_alpha
         outline_c = outline_c_array.tolist()
     else:

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -276,33 +276,6 @@ def _warn_groups(
         _warn_missing_groups(groups, color_source_vector, col_for_color)
 
 
-def _maybe_apply_transfunc(
-    colortype: ColorType,
-    color_vector: Any,
-    transfunc: abc.Callable[[Any], Any] | None,
-) -> Any:
-    """Apply ``transfunc`` to a continuous ``color_vector``; no-op when categorical/none or unset."""
-    if colortype == "continuous" and transfunc is not None:
-        return transfunc(color_vector)
-    return color_vector
-
-
-def _filter_groups_transparent_na(
-    groups: str | list[str],
-    color_source_vector: pd.Categorical,
-    color_vector: pd.Series | np.ndarray | list[str],
-) -> tuple[np.ndarray, pd.Categorical, np.ndarray]:
-    """Return a boolean mask and filtered color vectors for groups filtering.
-
-    Used when ``na_color=None`` (fully transparent) so that non-matching
-    elements are removed entirely instead of rendered invisibly.
-    """
-    keep = color_source_vector.isin(groups)
-    filtered_csv = color_source_vector[keep]
-    filtered_cv = np.asarray(color_vector)[keep]
-    return keep, filtered_csv, filtered_cv
-
-
 def _split_colorbar_params(
     params: dict[str, object] | None,
 ) -> tuple[dict[str, object], dict[str, object], str | None]:

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -33,9 +33,8 @@ from xarray import DataTree
 
 from spatialdata_plot._logging import _log_context, logger
 from spatialdata_plot.pl._color import (
+    ColorSpec,
     ColorType,
-    _align_outline_vector_to_length,
-    _apply_mask_to_outline_vectors,
     _color_vector_to_rgba,
     _get_colors_for_categorical_obs,
     _get_linear_colormap,
@@ -646,8 +645,7 @@ def _render_shapes(
 
     col_for_outline_color = render_params.col_for_outline_color
     outline_table_name = render_params.outline_table_name
-    outline_color_source_vector: pd.Series | None = None
-    outline_color_vector: Any = None
+    outline_color_spec: ColorSpec | None = None
     if col_for_outline_color is not None:
         # When the outline column lives in a table that hasn't been joined yet
         # (no fill table, or a different table than fill's), left-join it onto
@@ -675,51 +673,41 @@ def _render_shapes(
             table_layer=table_layer,
             coordinate_system=coordinate_system,
         )
-        outline_color_source_vector, outline_color_vector = (
-            outline_color_spec.source_vector,
-            outline_color_spec.color_vector,
-        )
         # Cross-table case: if fill and outline tables differ and the outline table does
         # not annotate every row of the (fill-joined) element, the vector length will
         # differ from the rendered element row count. Warn + align so per-shape lookup stays
         # well-defined.
         _n_shapes = len(sdata_filt[element])
-        if outline_color_vector is not None and len(outline_color_vector) != _n_shapes:
+        if len(outline_color_spec.color_vector) != _n_shapes:
             logger.warning(
                 f"Outline column '{col_for_outline_color}' does not fully annotate "
                 f"element '{element}' under its fill-joined alignment "
-                f"({len(outline_color_vector)} of {_n_shapes} rows). Missing rows will use na_color."
+                f"({len(outline_color_spec.color_vector)} of {_n_shapes} rows). Missing rows will use na_color."
             )
-            outline_color_vector, outline_color_source_vector = _align_outline_vector_to_length(
-                outline_color_vector,
-                outline_color_source_vector,
-                _n_shapes,
-            )
+            outline_color_spec = outline_color_spec.align_to_length(_n_shapes, render_params.cmap_params.na_color)
 
     _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
 
     # When groups are specified, filter out non-matching elements by default.
     # Only show non-matching elements if the user explicitly sets na_color.
     _na = render_params.cmap_params.na_color
-    if (
-        groups is not None
-        and color_spec.source_vector is not None
-        and (_na.default_color_set or _na.is_fully_transparent())
-    ):
+    if groups is not None and color_spec.is_categorical and (_na.default_color_set or _na.is_fully_transparent()):
         keep = color_spec.source_vector.isin(groups)
         color_spec = color_spec.filter(keep)
         shapes = shapes[keep].reset_index(drop=True)
         if len(shapes) == 0:
             return
         sdata_filt[element] = shapes
-        if outline_color_vector is not None:
-            outline_color_vector, outline_color_source_vector = _apply_mask_to_outline_vectors(
-                outline_color_vector, outline_color_source_vector, keep
-            )
+        if outline_color_spec is not None:
+            outline_color_spec = outline_color_spec.filter(keep)
 
-    # carrier pipeline done; unpack the final vectors for the read/draw phase below
     color_spec = color_spec.apply_transfunc(render_params.transfunc)
     color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
+    outline_color_source_vector, outline_color_vector = (
+        (outline_color_spec.source_vector, outline_color_spec.color_vector)
+        if outline_color_spec is not None
+        else (None, None)
+    )
 
     norm = render_params.cmap_params.fresh_norm()
 
@@ -1454,11 +1442,7 @@ def _render_points(
     # When groups are specified, filter out non-matching elements by default.
     # Only show non-matching elements if the user explicitly sets na_color.
     _na = render_params.cmap_params.na_color
-    if (
-        groups is not None
-        and color_spec.source_vector is not None
-        and (_na.default_color_set or _na.is_fully_transparent())
-    ):
+    if groups is not None and color_spec.is_categorical and (_na.default_color_set or _na.is_fully_transparent()):
         keep = color_spec.source_vector.isin(groups)
         color_spec = color_spec.filter(keep)
         n_points = int(keep.sum())
@@ -1469,7 +1453,6 @@ def _render_points(
         adata = adata[keep]
         _reparse_points(sdata_filt, element, points, transformation_in_cs, coordinate_system, col_for_color)
 
-    # carrier pipeline done; unpack the final vectors for the read/draw phase below
     color_spec = color_spec.apply_transfunc(render_params.transfunc)
     color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
@@ -2284,8 +2267,7 @@ def _render_labels(
     # to the outline vectors to keep lengths consistent.
     col_for_outline_color = render_params.col_for_outline_color
     outline_table_name = render_params.outline_table_name
-    outline_color_source_vector: pd.Series | None = None
-    outline_color_vector: Any = None
+    outline_color_spec: ColorSpec | None = None
     if col_for_outline_color is not None:
         outline_color_spec = resolve_color(
             sdata=sdata_filt,
@@ -2301,18 +2283,10 @@ def _render_labels(
             render_type="labels",
             coordinate_system=coordinate_system,
         )
-        outline_color_source_vector, outline_color_vector = (
-            outline_color_spec.source_vector,
-            outline_color_spec.color_vector,
-        )
         # Align to instance_id so the rasterize/groups masks (computed against
         # instance_id) can be applied without IndexError when the outline table
         # annotates a subset of the labels.
-        outline_color_vector, outline_color_source_vector = _align_outline_vector_to_length(
-            outline_color_vector,
-            outline_color_source_vector,
-            len(instance_id),
-        )
+        outline_color_spec = outline_color_spec.align_to_length(len(instance_id), render_params.cmap_params.na_color)
 
     # rasterize/downsampling can drop labels from the raster; remove their (now-absent) instance ids
     # so per-instance colors stay aligned and as_points does not emit dots for dropped cells.
@@ -2321,10 +2295,8 @@ def _render_labels(
         instance_id = instance_id[mask]
         if col_for_color is not None:
             color_spec = color_spec.filter(mask)
-        if outline_color_vector is not None:
-            outline_color_vector, outline_color_source_vector = _apply_mask_to_outline_vectors(
-                outline_color_vector, outline_color_source_vector, mask
-            )
+        if outline_color_spec is not None:
+            outline_color_spec = outline_color_spec.filter(mask)
 
     _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
 
@@ -2344,14 +2316,16 @@ def _render_labels(
         label.values[~keep_mask] = 0
         instance_id = instance_id[keep_vec]
         color_spec = color_spec.filter(keep_vec)
-        if outline_color_vector is not None:
-            outline_color_vector, outline_color_source_vector = _apply_mask_to_outline_vectors(
-                outline_color_vector, outline_color_source_vector, keep_vec
-            )
+        if outline_color_spec is not None:
+            outline_color_spec = outline_color_spec.filter(keep_vec)
 
-    # carrier pipeline done; unpack the final vectors for the read/draw phase below
     color_spec = color_spec.apply_transfunc(render_params.transfunc)
     color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
+    outline_color_source_vector, outline_color_vector = (
+        (outline_color_spec.source_vector, outline_color_spec.color_vector)
+        if outline_color_spec is not None
+        else (None, None)
+    )
 
     if render_params.as_points:
         # Fast mode: one dot per label at its centroid. Compute on the *rendered* raster (already

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -34,7 +34,6 @@ from xarray import DataTree
 from spatialdata_plot._logging import _log_context, logger
 from spatialdata_plot.pl._color import (
     ColorSpec,
-    ColorType,
     _get_colors_for_categorical_obs,
     _get_linear_colormap,
     _map_color_seg,
@@ -325,16 +324,6 @@ def _should_request_colorbar(
     return bool(auto_condition)
 
 
-def _make_palette(
-    color_source_vector: pd.Series | None,
-    color_vector: Any,
-) -> ListedColormap:
-    """Build a ListedColormap from a color vector, filtering out NaN entries when categorical."""
-    if color_source_vector is None:
-        return ListedColormap(dict.fromkeys(color_vector))
-    return ListedColormap(dict.fromkeys(color_vector[~pd.Categorical(color_source_vector).isnull()]))
-
-
 def _add_legend_and_colorbar(
     ax: matplotlib.axes.SubplotBase,
     cax: ScalarMappable | None,
@@ -371,7 +360,7 @@ def _add_legend_and_colorbar(
         return
 
     if palette is None and fill_has_decorations:
-        palette = _make_palette(color_source_vector, color_vector)
+        palette = color_spec.make_palette()
 
     if color_source_vector is not None and hasattr(color_source_vector, "remove_unused_categories"):
         color_source_vector = color_source_vector.remove_unused_categories()
@@ -633,7 +622,6 @@ def _render_shapes(
         table_layer=table_layer,
         coordinate_system=coordinate_system,
     )
-    colortype = color_spec.colortype
 
     col_for_outline_color = render_params.col_for_outline_color
     outline_table_name = render_params.outline_table_name
@@ -692,24 +680,19 @@ def _render_shapes(
             outline_color_spec = outline_color_spec.filter(keep)
 
     color_spec = color_spec.apply_transfunc(render_params.transfunc)
-    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
-    outline_color_source_vector, outline_color_vector = (
-        (outline_color_spec.source_vector, outline_color_spec.color_vector)
-        if outline_color_spec is not None
-        else (None, None)
-    )
 
     norm = render_params.cmap_params.fresh_norm()
 
-    if len(color_vector) == 0:
-        color_vector = [render_params.cmap_params.na_color.get_hex_with_alpha()]
+    if len(color_spec.color_vector) == 0:
+        color_spec = color_spec.with_color_vector([render_params.cmap_params.na_color.get_hex_with_alpha()])
 
     # continuous case: leave NaNs as NaNs; utils maps them to na_color during draw
     if color_spec.is_continuous:
-        _series = color_vector if isinstance(color_vector, pd.Series) else pd.Series(color_vector)
+        cv = color_spec.color_vector
+        _series = cv if isinstance(cv, pd.Series) else pd.Series(cv)
 
         try:
-            color_vector = np.asarray(_series, dtype=float)
+            cv = np.asarray(_series, dtype=float)
         except (TypeError, ValueError):
             nan_count = int(_series.isna().sum())
             if nan_count:
@@ -717,24 +700,25 @@ def _render_shapes(
                     f"Found {nan_count} NaN values in color data. "
                     "These observations will be colored with the 'na_color'."
                 )
-            color_vector = _series.to_numpy()
+            cv = _series.to_numpy()
         else:
-            if np.isnan(color_vector).any():
-                nan_count = int(np.isnan(color_vector).sum())
+            if np.isnan(cv).any():
+                nan_count = int(np.isnan(cv).sum())
                 logger.warning(
                     f"Found {nan_count} NaN values in color data. "
                     "These observations will be colored with the 'na_color'."
                 )
+        color_spec = color_spec.with_color_vector(cv)
 
-    palette = _make_palette(color_source_vector, color_vector)
+    palette = color_spec.make_palette()
 
     has_valid_color = (
-        len(set(color_vector)) != 1
-        or list(set(color_vector))[0] != render_params.cmap_params.na_color.get_hex_with_alpha()
+        len(set(color_spec.color_vector)) != 1
+        or list(set(color_spec.color_vector))[0] != render_params.cmap_params.na_color.get_hex_with_alpha()
     )
-    if has_valid_color and color_source_vector is not None and col_for_color is not None:
+    if has_valid_color and color_spec.is_categorical and col_for_color is not None:
         # necessary in case different shapes elements are annotated with one table
-        color_source_vector = color_source_vector.remove_unused_categories()
+        color_spec = color_spec.with_source_vector(color_spec.source_vector.remove_unused_categories())
 
     shapes = gpd.GeoDataFrame(shapes, geometry="geometry")
 
@@ -749,9 +733,7 @@ def _render_shapes(
             render_params,
             x=xy[:, 0],
             y=xy[:, 1],
-            color_vector=color_vector,
-            color_source_vector=color_source_vector,
-            colortype=colortype,
+            color_spec=color_spec,
             norm=norm,
             na_color=render_params.cmap_params.na_color,
             adata=table,
@@ -834,6 +816,10 @@ def _render_shapes(
 
         cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, x_range=x_ext, y_range=y_ext)
 
+        # datashader consumes raw arrays; unpack the carrier for this leaf and re-wrap its result
+        color_vector = color_spec.color_vector
+        color_source_vector = color_spec.source_vector
+
         # in case we are coloring by a column in table
         if col_for_color is not None and col_for_color not in transformed_element.columns:
             # Ensure color vector length matches the number of shapes
@@ -875,6 +861,7 @@ def _render_shapes(
             default_reduction=_default_reduction,
             kind="shapes",
         )
+        color_spec = color_spec.with_color_vector(color_vector)
 
         _render_ds_outlines(
             cvs,
@@ -885,8 +872,8 @@ def _render_shapes(
             factor,
             x_min=x_ext[0],
             y_min=y_ext[0],
-            outline_color_vector=outline_color_vector,
-            outline_color_source_vector=outline_color_source_vector,
+            outline_color_vector=outline_color_spec.color_vector if outline_color_spec is not None else None,
+            outline_color_source_vector=outline_color_spec.source_vector if outline_color_spec is not None else None,
         )
 
         _cax = _render_ds_image(
@@ -988,7 +975,7 @@ def _render_shapes(
 
     if color_spec.is_continuous:
         # Colorbar range from the same resolved norm the fill pixels use.
-        used_norm = _resolve_continuous_norm(color_vector, render_params.cmap_params)
+        used_norm = _resolve_continuous_norm(color_spec.color_vector, render_params.cmap_params)
         _cax.set_clim(vmin=used_norm.vmin, vmax=used_norm.vmax)
 
     _add_legend_and_colorbar(
@@ -997,7 +984,7 @@ def _render_shapes(
         fig_params=fig_params,
         adata=table,
         col_for_color=col_for_color,
-        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
+        color_spec=color_spec,
         palette=palette,
         alpha=render_params.fill_alpha,
         na_color=render_params.cmap_params.na_color,
@@ -1077,9 +1064,7 @@ def _render_centroids_as_points(
     *,
     x: Any,
     y: Any,
-    color_vector: Any,
-    color_source_vector: pd.Series | None,
-    colortype: ColorType,
+    color_spec: ColorSpec,
     norm: Normalize | None,
     na_color: Any,
     adata: AnnData | None,
@@ -1100,12 +1085,12 @@ def _render_centroids_as_points(
     method = _resolve_as_points_method(render_params, n=len(x), allow_datashader=allow_datashader)
     if method == "datashader":
         df = pd.DataFrame({"x": x, "y": y})
-        cax, color_vector, color_source_vector = _datashader_points(
+        cax, cv, csv = _datashader_points(
             ax,
             df,
             col_for_color=col_for_color,
-            color_vector=color_vector,
-            color_source_vector=color_source_vector,
+            color_vector=color_spec.color_vector,
+            color_source_vector=color_spec.source_vector,
             norm=norm,
             cmap_params=render_params.cmap_params,
             alpha=render_params.fill_alpha,
@@ -1121,12 +1106,13 @@ def _render_centroids_as_points(
             as_markers=True,
             axes_extent=axes_extent,
         )
+        color_spec = color_spec.with_source_vector(csv).with_color_vector(cv)
     else:
         cax = _scatter_points(
             ax,
             x,
             y,
-            color_vector,
+            color_spec.color_vector,
             size=render_params.size,
             cmap=render_params.cmap_params.cmap,
             norm=norm,
@@ -1140,7 +1126,7 @@ def _render_centroids_as_points(
         fig_params=fig_params,
         adata=adata,
         col_for_color=col_for_color,
-        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
+        color_spec=color_spec,
         palette=palette,
         alpha=render_params.fill_alpha,
         na_color=na_color,
@@ -1405,7 +1391,6 @@ def _render_points(
         coordinate_system=coordinate_system,
         preloaded_color_data=_preloaded,
     )
-    colortype = color_spec.colortype
 
     if added_color_from_table and col_for_color is not None:
         _reparse_points(
@@ -1431,7 +1416,6 @@ def _render_points(
         _reparse_points(sdata_filt, element, points, transformation_in_cs, coordinate_system, col_for_color)
 
     color_spec = color_spec.apply_transfunc(render_params.transfunc)
-    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     trans, trans_data = _prepare_transformation(sdata.points[element], coordinate_system, ax)
 
@@ -1464,12 +1448,12 @@ def _render_points(
             # any other elements on the axes.
             return
 
-        cax, color_vector, color_source_vector = _datashader_points(
+        cax, cv, csv = _datashader_points(
             ax,
             transformed_element,
             col_for_color=col_for_color,
-            color_vector=color_vector,
-            color_source_vector=color_source_vector,
+            color_vector=color_spec.color_vector,
+            color_source_vector=color_spec.source_vector,
             norm=norm,
             cmap_params=render_params.cmap_params,
             alpha=render_params.alpha,
@@ -1481,6 +1465,7 @@ def _render_points(
             fig_params=fig_params,
             default_reduction=_default_reduction,
         )
+        color_spec = color_spec.with_source_vector(csv).with_color_vector(cv)
 
     elif method == "matplotlib":
         # update axis limits if plot was empty before (necessary if datashader comes after)
@@ -1489,7 +1474,7 @@ def _render_points(
             ax,
             adata[:, 0].X.flatten(),
             adata[:, 1].X.flatten(),
-            color_vector,
+            color_spec.color_vector,
             size=render_params.size,
             cmap=render_params.cmap_params.cmap,
             norm=norm,
@@ -1509,7 +1494,7 @@ def _render_points(
         fig_params=fig_params,
         adata=adata,
         col_for_color=col_for_color,
-        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
+        color_spec=color_spec,
         palette=None,
         alpha=render_params.alpha,
         na_color=render_params.cmap_params.na_color,
@@ -2234,7 +2219,6 @@ def _render_labels(
         render_type="labels",
         coordinate_system=coordinate_system,
     )
-    colortype = color_spec.colortype
 
     # Outline color lookup must run BEFORE any masking so the returned vector aligns to
     # the original instance_id. The same masks applied to fill below are then applied
@@ -2288,7 +2272,7 @@ def _render_labels(
             outline_color_spec = outline_color_spec.filter(keep_vec)
 
     color_spec = color_spec.apply_transfunc(render_params.transfunc)
-    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
+    # outline still feeds the _map_color_seg leaf as loose arrays
     outline_color_source_vector, outline_color_vector = (
         (outline_color_spec.source_vector, outline_color_spec.color_vector)
         if outline_color_spec is not None
@@ -2320,10 +2304,10 @@ def _render_labels(
             point_color_vector = np.random.default_rng(42).random((len(point_ids), 3))
             point_color_source_vector = None
             allow_datashader = False
-        elif len(color_vector) == len(instance_id):
+        elif len(color_spec.color_vector) == len(instance_id):
             # data-driven colour is per-instance
-            point_color_vector = np.asarray(color_vector)[keep]
-            point_color_source_vector = None if color_source_vector is None else color_source_vector[keep]
+            point_color_vector = np.asarray(color_spec.color_vector)[keep]
+            point_color_source_vector = None if color_spec.source_vector is None else color_spec.source_vector[keep]
         else:
             # literal colour / user-set na_color -> one colour per centroid
             point_color_vector = np.full(len(point_ids), na_color.get_hex_with_alpha())
@@ -2335,9 +2319,7 @@ def _render_labels(
             render_params,
             x=xy[:, 0],
             y=xy[:, 1],
-            color_vector=point_color_vector,
-            color_source_vector=point_color_source_vector,
-            colortype=colortype,
+            color_spec=ColorSpec(color_spec.colortype, point_color_source_vector, point_color_vector),
             norm=render_params.cmap_params.fresh_norm(),  # ax.scatter autoscales in place; don't mutate the shared norm
             na_color=na_color,
             adata=table if table_name is not None else None,
@@ -2360,8 +2342,8 @@ def _render_labels(
         labels = _map_color_seg(
             seg=label.values,
             cell_id=instance_id,
-            color_vector=color_vector,
-            color_source_vector=color_source_vector,
+            color_vector=color_spec.color_vector,
+            color_source_vector=color_spec.source_vector,
             cmap_params=render_params.cmap_params,
             seg_erosionpx=seg_erosionpx,
             seg_boundaries=seg_boundaries,
@@ -2378,7 +2360,7 @@ def _render_labels(
             cmap=None if color_spec.is_categorical else render_params.cmap_params.cmap,
             norm=None
             if color_spec.is_categorical
-            else _resolve_continuous_norm(color_vector, render_params.cmap_params),
+            else _resolve_continuous_norm(color_spec.color_vector, render_params.cmap_params),
             alpha=alpha,
             origin="lower",
             zorder=render_params.zorder,
@@ -2446,7 +2428,7 @@ def _render_labels(
         fig_params=fig_params,
         adata=table,
         col_for_color=col_for_color,
-        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
+        color_spec=color_spec,
         palette=palette,
         alpha=alpha_to_decorate_ax,
         na_color=render_params.cmap_params.na_color,
@@ -2457,7 +2439,9 @@ def _render_labels(
         outline_col_for_color=col_for_outline_color,
         outline_color_spec=outline_color_spec,
         outline_cmap_params=render_params.cmap_params,
-        na_in_legend_override=(legend_params.na_in_legend if groups is None else len(groups) == len(set(color_vector))),
+        na_in_legend_override=(
+            legend_params.na_in_legend if groups is None else len(groups) == len(set(color_spec.color_vector))
+        ),
     )
 
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -362,7 +362,7 @@ def _add_legend_and_colorbar(
     if palette is None and fill_has_decorations:
         palette = color_spec.make_palette()
 
-    if color_source_vector is not None and hasattr(color_source_vector, "remove_unused_categories"):
+    if color_spec.is_categorical:
         color_source_vector = color_source_vector.remove_unused_categories()
 
     wants_colorbar = _should_request_colorbar(
@@ -690,31 +690,24 @@ def _render_shapes(
     if color_spec.is_continuous:
         cv = color_spec.color_vector
         _series = cv if isinstance(cv, pd.Series) else pd.Series(cv)
-
         try:
             cv = np.asarray(_series, dtype=float)
         except (TypeError, ValueError):
-            nan_count = int(_series.isna().sum())
-            if nan_count:
-                logger.warning(
-                    f"Found {nan_count} NaN values in color data. "
-                    "These observations will be colored with the 'na_color'."
-                )
             cv = _series.to_numpy()
-        else:
-            if np.isnan(cv).any():
-                nan_count = int(np.isnan(cv).sum())
-                logger.warning(
-                    f"Found {nan_count} NaN values in color data. "
-                    "These observations will be colored with the 'na_color'."
-                )
+        nan_count = int(pd.isna(cv).sum())
+        if nan_count:
+            logger.warning(
+                f"Found {nan_count} NaN values in color data. "
+                "These observations will be colored with the 'na_color'."
+            )
         color_spec = color_spec.evolve(color_vector=cv)
 
     palette = color_spec.make_palette()
 
+    distinct_colors = set(color_spec.color_vector)
     has_valid_color = (
-        len(set(color_spec.color_vector)) != 1
-        or list(set(color_spec.color_vector))[0] != render_params.cmap_params.na_color.get_hex_with_alpha()
+        len(distinct_colors) != 1
+        or next(iter(distinct_colors)) != render_params.cmap_params.na_color.get_hex_with_alpha()
     )
     if has_valid_color and color_spec.is_categorical and col_for_color is not None:
         # necessary in case different shapes elements are annotated with one table

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -341,9 +341,7 @@ def _add_legend_and_colorbar(
     fig_params: FigParams,
     adata: AnnData | None,
     col_for_color: str | None,
-    colortype: ColorType,
-    color_source_vector: pd.Series | None,
-    color_vector: Any,
+    color_spec: ColorSpec,
     palette: ListedColormap | list[str] | None,
     alpha: float,
     na_color: Color,
@@ -352,19 +350,21 @@ def _add_legend_and_colorbar(
     colorbar_params: dict[str, object] | None,
     colorbar_requests: list[ColorbarSpec] | None,
     outline_col_for_color: str | None = None,
-    outline_color_source_vector: pd.Series | None = None,
-    outline_color_vector: Any | None = None,
+    outline_color_spec: ColorSpec | None = None,
     outline_cmap_params: CmapParams | None = None,
     na_in_legend_override: bool | None = None,
 ) -> None:
-    """Add legend and colorbar decorations if the color vector warrants them.
+    """Add legend and colorbar decorations if the color warrants them.
 
-    A continuous colorbar is requested for ``colortype == "continuous"``; ``na_in_legend_override``
-    lets labels adjust ``na_in_legend`` for groups while sharing this body.
+    A continuous colorbar is requested for a continuous fill; ``na_in_legend_override`` lets labels
+    adjust ``na_in_legend`` for groups while sharing this body.
     """
+    color_source_vector = color_spec.source_vector
+    color_vector = color_spec.color_vector
     fill_has_decorations = _want_decorations(color_vector, na_color) and col_for_color is not None
-    outline_has_decorations = outline_col_for_color is not None and (
-        outline_color_source_vector is not None or outline_color_vector is not None
+    # only a categorical/continuous outline decorates; the none state (na-array source) carries nothing
+    outline_has_decorations = (
+        outline_col_for_color is not None and outline_color_spec is not None and not outline_color_spec.is_none
     )
 
     if not fill_has_decorations and not outline_has_decorations:
@@ -377,17 +377,15 @@ def _add_legend_and_colorbar(
         color_source_vector = color_source_vector.remove_unused_categories()
 
     wants_colorbar = _should_request_colorbar(
-        colorbar,
-        has_mappable=cax is not None,
-        is_continuous=col_for_color is not None and colortype == "continuous",
+        colorbar, has_mappable=cax is not None, is_continuous=color_spec.is_continuous
     )
 
     if fill_has_decorations:
         # Auto-title the fill legend only when an outline legend will also be drawn.
-        outline_legend_will_render = outline_has_decorations and outline_color_source_vector is not None
+        outline_legend_will_render = outline_has_decorations and outline_color_spec.is_categorical
         if legend_params.legend_title is not None:
             fill_title: str | None = legend_params.legend_title or None
-        elif outline_legend_will_render and color_source_vector is not None:
+        elif outline_legend_will_render and color_spec.is_categorical:
             fill_title = "fill"
         else:
             fill_title = None
@@ -422,13 +420,12 @@ def _add_legend_and_colorbar(
             ax=ax,
             fig_params=fig_params,
             outline_col=cast(str, outline_col_for_color),
-            outline_color_source_vector=outline_color_source_vector,
-            outline_color_vector=outline_color_vector,
+            outline_color_spec=outline_color_spec,
             cmap_params=outline_cmap_params,
             colorbar_params=colorbar_params,
             colorbar_requests=colorbar_requests,
             legend_params=legend_params,
-            fill_has_legend=fill_has_decorations and color_source_vector is not None,
+            fill_has_legend=fill_has_decorations and color_spec.is_categorical,
             alpha=alpha,
         )
 
@@ -437,8 +434,7 @@ def _decorate_outline(
     ax: matplotlib.axes.SubplotBase,
     fig_params: FigParams,
     outline_col: str,
-    outline_color_source_vector: pd.Series | None,
-    outline_color_vector: Any,
+    outline_color_spec: ColorSpec,
     cmap_params: CmapParams,
     colorbar_params: dict[str, object] | None,
     colorbar_requests: list[ColorbarSpec] | None,
@@ -447,21 +443,21 @@ def _decorate_outline(
     alpha: float,
 ) -> None:
     """Dispatch a categorical legend or continuous colorbar for an outline column."""
-    if outline_color_source_vector is not None:
+    if outline_color_spec.is_categorical:
         _add_outline_legend(
             ax=ax,
             fig_params=fig_params,
             outline_col=outline_col,
-            outline_color_source_vector=outline_color_source_vector,
-            outline_color_vector=outline_color_vector,
+            outline_color_source_vector=outline_color_spec.source_vector,
+            outline_color_vector=outline_color_spec.color_vector,
             fill_has_legend=fill_has_legend,
             legend_params=legend_params,
         )
-    elif colorbar_requests is not None and legend_params.colorbar and outline_color_vector is not None:
+    elif colorbar_requests is not None and legend_params.colorbar:
         _append_outline_colorbar(
             colorbar_requests=colorbar_requests,
             ax=ax,
-            outline_color_vector=outline_color_vector,
+            outline_color_vector=outline_color_spec.color_vector,
             cmap_params=cmap_params,
             colorbar_params=colorbar_params,
             outline_col=outline_col,
@@ -1001,9 +997,7 @@ def _render_shapes(
         fig_params=fig_params,
         adata=table,
         col_for_color=col_for_color,
-        colortype=colortype,
-        color_source_vector=color_source_vector,
-        color_vector=color_vector,
+        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
         palette=palette,
         alpha=render_params.fill_alpha,
         na_color=render_params.cmap_params.na_color,
@@ -1012,8 +1006,7 @@ def _render_shapes(
         colorbar_params=render_params.colorbar_params,
         colorbar_requests=colorbar_requests,
         outline_col_for_color=col_for_outline_color,
-        outline_color_source_vector=outline_color_source_vector,
-        outline_color_vector=outline_color_vector,
+        outline_color_spec=outline_color_spec,
         outline_cmap_params=render_params.cmap_params,
     )
 
@@ -1147,9 +1140,7 @@ def _render_centroids_as_points(
         fig_params=fig_params,
         adata=adata,
         col_for_color=col_for_color,
-        colortype=colortype,
-        color_source_vector=color_source_vector,
-        color_vector=color_vector,
+        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
         palette=palette,
         alpha=render_params.fill_alpha,
         na_color=na_color,
@@ -1518,9 +1509,7 @@ def _render_points(
         fig_params=fig_params,
         adata=adata,
         col_for_color=col_for_color,
-        colortype=colortype,
-        color_source_vector=color_source_vector,
-        color_vector=color_vector,
+        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
         palette=None,
         alpha=render_params.alpha,
         na_color=render_params.cmap_params.na_color,
@@ -2457,9 +2446,7 @@ def _render_labels(
         fig_params=fig_params,
         adata=table,
         col_for_color=col_for_color,
-        colortype=colortype,
-        color_source_vector=color_source_vector,
-        color_vector=color_vector,
+        color_spec=ColorSpec(colortype, color_source_vector, color_vector),
         palette=palette,
         alpha=alpha_to_decorate_ax,
         na_color=render_params.cmap_params.na_color,
@@ -2468,8 +2455,7 @@ def _render_labels(
         colorbar_params=render_params.colorbar_params,
         colorbar_requests=colorbar_requests,
         outline_col_for_color=col_for_outline_color,
-        outline_color_source_vector=outline_color_source_vector,
-        outline_color_vector=outline_color_vector,
+        outline_color_spec=outline_color_spec,
         outline_cmap_params=render_params.cmap_params,
         na_in_legend_override=(legend_params.na_in_legend if groups is None else len(groups) == len(set(color_vector))),
     )

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -269,8 +269,7 @@ def _warn_groups(
 ) -> None:
     """Emit the two groups-related warnings every ``_render_*`` preamble shares."""
     _warn_groups_ignored_continuous(groups, colortype, col_for_color)
-    # Only a categorical source has `.categories` to check groups against; the none state
-    # (na-array source) must not reach _warn_missing_groups (it has no categories).
+    # only a categorical source has `.categories`; the none state (na-array source) must not reach it
     if groups is not None and colortype == "categorical":
         _warn_missing_groups(groups, color_source_vector, col_for_color)
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -35,7 +35,6 @@ from spatialdata_plot._logging import _log_context, logger
 from spatialdata_plot.pl._color import (
     ColorSpec,
     ColorType,
-    _color_vector_to_rgba,
     _get_colors_for_categorical_obs,
     _get_linear_colormap,
     _map_color_seg,
@@ -917,12 +916,7 @@ def _render_shapes(
 
         # render outlines separately to ensure they are always underneath the shape
         if col_for_outline_color is not None and render_params.outline_alpha[0] > 0:
-            outline_rgba = _color_vector_to_rgba(
-                outline_color_vector,
-                outline_color_source_vector,
-                render_params.cmap_params,
-                n_rows=len(shapes),
-            )
+            outline_rgba = outline_color_spec.to_rgba(render_params.cmap_params)
             _cax = _get_collection_shape(
                 shapes=shapes,
                 s=render_params.scale,
@@ -984,7 +978,7 @@ def _render_shapes(
         _cax = _get_collection_shape(
             shapes=shapes,
             s=render_params.scale,
-            c=color_vector.copy(),  # copy bc c is modified in _get_collection_shape
+            c=color_spec.to_rgba(render_params.cmap_params),
             prebuilt_patches=prebuilt_patches,
             render_params=render_params,
             rasterized=sc_settings._vector_friendly,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -206,17 +206,16 @@ def _reject_continuous_color_under_density(
     sdata_filt: sd.SpatialData,
     element: str,
     col_for_color: str | None,
-    color_source_vector: Any,
+    colortype: ColorType,
     color_vector: Any,
 ) -> None:
     """Raise before any materialization if density+continuous-color was requested.
 
-    ``color_source_vector`` is only populated by ``_set_color_source_vec`` for the categorical
-    branch, so a non-None value is sufficient to accept the call. Otherwise we read the dtype
-    from the dask source (points element column) or the pre-computed color vector — neither
-    forces a ``.compute()``.
+    Only ``continuous`` coloring is rejected; categorical and none are fine. When the colortype
+    is not yet decisive we read the dtype from the dask source (points element column) or the
+    pre-computed color vector — neither forces a ``.compute()``.
     """
-    if col_for_color is None or color_source_vector is not None:
+    if col_for_color is None or colortype != "continuous":
         return
     points_columns = sdata_filt.points[element].columns
     if col_for_color in points_columns:
@@ -271,8 +270,9 @@ def _warn_groups(
 ) -> None:
     """Emit the two groups-related warnings every ``_render_*`` preamble shares."""
     _warn_groups_ignored_continuous(groups, colortype, col_for_color)
-    # behaviour-preserving: `color_source_vector is not None` == colortype != "continuous"
-    if groups is not None and colortype != "continuous":
+    # Only a categorical source has `.categories` to check groups against; the none state
+    # (na-array source) must not reach _warn_missing_groups (it has no categories).
+    if groups is not None and colortype == "categorical":
         _warn_missing_groups(groups, color_source_vector, col_for_color)
 
 
@@ -656,7 +656,7 @@ def _render_shapes(
     trans, trans_data = _prepare_transformation(sdata_filt.shapes[element], coordinate_system)
 
     # get color vector (categorical or continuous)
-    _spec = resolve_color(
+    color_spec = resolve_color(
         sdata=sdata_filt,
         element=sdata_filt[element],
         element_name=element,
@@ -669,11 +669,8 @@ def _render_shapes(
         table_layer=table_layer,
         coordinate_system=coordinate_system,
     )
-    colortype = _spec.colortype
-    color_source_vector, color_vector = _spec.source_vector, _spec.color_vector
-
-    # behaviour-preserving: `color_source_vector is not None` == colortype != "continuous"
-    values_are_categorical = colortype != "continuous"
+    colortype = color_spec.colortype
+    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     col_for_outline_color = render_params.col_for_outline_color
     outline_table_name = render_params.outline_table_name
@@ -693,7 +690,7 @@ def _render_shapes(
             # so the per-shape outline vector length matches the rendered shapes.
             if table_name is None:
                 sdata_filt[element] = shapes = joined_outline_element
-        _outline_spec = resolve_color(
+        outline_color_spec = resolve_color(
             sdata=sdata_filt,
             element=sdata_filt[element],
             element_name=element,
@@ -706,7 +703,10 @@ def _render_shapes(
             table_layer=table_layer,
             coordinate_system=coordinate_system,
         )
-        outline_color_source_vector, outline_color_vector = _outline_spec.source_vector, _outline_spec.color_vector
+        outline_color_source_vector, outline_color_vector = (
+            outline_color_spec.source_vector,
+            outline_color_spec.color_vector,
+        )
         # Cross-table case: if fill and outline tables differ and the outline table does
         # not annotate every row of the (fill-joined) element, the vector length will
         # differ from the rendered element row count. Warn + align so per-shape lookup stays
@@ -750,7 +750,7 @@ def _render_shapes(
         color_vector = [render_params.cmap_params.na_color.get_hex_with_alpha()]
 
     # continuous case: leave NaNs as NaNs; utils maps them to na_color during draw
-    if color_source_vector is None and not values_are_categorical:
+    if color_spec.is_continuous:
         _series = color_vector if isinstance(color_vector, pd.Series) else pd.Series(color_vector)
 
         try:
@@ -1036,7 +1036,7 @@ def _render_shapes(
         for path in _cax.get_paths():
             path.vertices = trans.transform(path.vertices)
 
-    if not values_are_categorical:
+    if color_spec.is_continuous:
         # Colorbar range from the same resolved norm the fill pixels use.
         used_norm = _resolve_continuous_norm(color_vector, render_params.cmap_params)
         _cax.set_clim(vmin=used_norm.vmin, vmax=used_norm.vmax)
@@ -1445,7 +1445,7 @@ def _render_points(
         else None
     )
 
-    _spec = resolve_color(
+    color_spec = resolve_color(
         sdata=sdata_filt,
         element=color_element,
         element_name=element,
@@ -1460,8 +1460,8 @@ def _render_points(
         coordinate_system=coordinate_system,
         preloaded_color_data=_preloaded,
     )
-    colortype = _spec.colortype
-    color_source_vector, color_vector = _spec.source_vector, _spec.color_vector
+    colortype = color_spec.colortype
+    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     if added_color_from_table and col_for_color is not None:
         _reparse_points(
@@ -1500,7 +1500,7 @@ def _render_points(
 
     if render_params.density:
         method = "datashader"
-        _reject_continuous_color_under_density(sdata_filt, element, col_for_color, color_source_vector, color_vector)
+        _reject_continuous_color_under_density(sdata_filt, element, col_for_color, colortype, color_vector)
     elif method is None:
         method = "datashader" if n_points > 10000 else "matplotlib"
 
@@ -2281,7 +2281,7 @@ def _render_labels(
         if col_for_color is None and render_params.color is not None
         else render_params.cmap_params.na_color
     )
-    _spec = resolve_color(
+    color_spec = resolve_color(
         sdata=sdata_filt,
         element=label,
         element_name=element,
@@ -2295,9 +2295,9 @@ def _render_labels(
         render_type="labels",
         coordinate_system=coordinate_system,
     )
-    colortype = _spec.colortype
-    color_source_vector, color_vector = _spec.source_vector, _spec.color_vector
-    categorical = colortype == "categorical"
+    colortype = color_spec.colortype
+    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
+    categorical = color_spec.is_categorical
 
     # Outline color lookup must run BEFORE any masking so the returned vector aligns to
     # the original instance_id. The same masks applied to fill below are then applied
@@ -2307,7 +2307,7 @@ def _render_labels(
     outline_color_source_vector: pd.Series | None = None
     outline_color_vector: Any = None
     if col_for_outline_color is not None:
-        _outline_spec = resolve_color(
+        outline_color_spec = resolve_color(
             sdata=sdata_filt,
             element=label,
             element_name=element,
@@ -2321,7 +2321,10 @@ def _render_labels(
             render_type="labels",
             coordinate_system=coordinate_system,
         )
-        outline_color_source_vector, outline_color_vector = _outline_spec.source_vector, _outline_spec.color_vector
+        outline_color_source_vector, outline_color_vector = (
+            outline_color_spec.source_vector,
+            outline_color_spec.color_vector,
+        )
         # Align to instance_id so the rasterize/groups masks (computed against
         # instance_id) can be applied without IndexError when the outline table
         # annotates a subset of the labels.

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -1465,7 +1465,6 @@ def _render_points(
         preloaded_color_data=_preloaded,
     )
     colortype = color_spec.colortype
-    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     if added_color_from_table and col_for_color is not None:
         _reparse_points(
@@ -1477,15 +1476,18 @@ def _render_points(
             col_for_color,
         )
 
-    _warn_groups(groups, colortype, color_source_vector, col_for_color)
+    _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
 
     # When groups are specified, filter out non-matching elements by default.
     # Only show non-matching elements if the user explicitly sets na_color.
     _na = render_params.cmap_params.na_color
-    if groups is not None and color_source_vector is not None and (_na.default_color_set or _na.is_fully_transparent()):
-        keep, color_source_vector, color_vector = _filter_groups_transparent_na(
-            groups, color_source_vector, color_vector
-        )
+    if (
+        groups is not None
+        and color_spec.source_vector is not None
+        and (_na.default_color_set or _na.is_fully_transparent())
+    ):
+        keep = color_spec.source_vector.isin(groups)
+        color_spec = color_spec.filter(keep)
         n_points = int(keep.sum())
         if n_points == 0:
             return
@@ -1494,7 +1496,9 @@ def _render_points(
         adata = adata[keep]
         _reparse_points(sdata_filt, element, points, transformation_in_cs, coordinate_system, col_for_color)
 
-    color_vector = _maybe_apply_transfunc(colortype, color_vector, render_params.transfunc)
+    # carrier pipeline done; unpack the final vectors for the read/draw phase below
+    color_spec = color_spec.apply_transfunc(render_params.transfunc)
+    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     trans, trans_data = _prepare_transformation(sdata.points[element], coordinate_system, ax)
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -684,7 +684,7 @@ def _render_shapes(
     norm = render_params.cmap_params.fresh_norm()
 
     if len(color_spec.color_vector) == 0:
-        color_spec = color_spec.with_color_vector([render_params.cmap_params.na_color.get_hex_with_alpha()])
+        color_spec = color_spec.evolve(color_vector=[render_params.cmap_params.na_color.get_hex_with_alpha()])
 
     # continuous case: leave NaNs as NaNs; utils maps them to na_color during draw
     if color_spec.is_continuous:
@@ -708,7 +708,7 @@ def _render_shapes(
                     f"Found {nan_count} NaN values in color data. "
                     "These observations will be colored with the 'na_color'."
                 )
-        color_spec = color_spec.with_color_vector(cv)
+        color_spec = color_spec.evolve(color_vector=cv)
 
     palette = color_spec.make_palette()
 
@@ -718,7 +718,7 @@ def _render_shapes(
     )
     if has_valid_color and color_spec.is_categorical and col_for_color is not None:
         # necessary in case different shapes elements are annotated with one table
-        color_spec = color_spec.with_source_vector(color_spec.source_vector.remove_unused_categories())
+        color_spec = color_spec.evolve(source_vector=color_spec.source_vector.remove_unused_categories())
 
     shapes = gpd.GeoDataFrame(shapes, geometry="geometry")
 
@@ -816,7 +816,7 @@ def _render_shapes(
 
         cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, x_range=x_ext, y_range=y_ext)
 
-        # datashader consumes raw arrays; unpack the carrier for this leaf and re-wrap its result
+        # datashader leaf consumes raw arrays; re-wrapped into the carrier after aggregation
         color_vector = color_spec.color_vector
         color_source_vector = color_spec.source_vector
 
@@ -839,8 +839,9 @@ def _render_shapes(
                         color_vector = list(color_vector) + [na_color] * (len(transformed_element) - len(color_vector))
 
             transformed_element[col_for_color] = color_vector if color_source_vector is None else color_source_vector
-        # Render shapes with datashader
-        color_by_categorical = color_spec.is_categorical
+        # Render shapes with datashader: categorical AND none (na-array) go through the categorical
+        # color-key path; only continuous uses the numeric reduction.
+        color_by_categorical = col_for_color is not None and not color_spec.is_continuous
         if color_by_categorical:
             cat_series = transformed_element[col_for_color]
             if not isinstance(cat_series.dtype, pd.CategoricalDtype):
@@ -861,7 +862,7 @@ def _render_shapes(
             default_reduction=_default_reduction,
             kind="shapes",
         )
-        color_spec = color_spec.with_color_vector(color_vector)
+        color_spec = color_spec.evolve(color_vector=color_vector)
 
         _render_ds_outlines(
             cvs,
@@ -1106,7 +1107,7 @@ def _render_centroids_as_points(
             as_markers=True,
             axes_extent=axes_extent,
         )
-        color_spec = color_spec.with_source_vector(csv).with_color_vector(cv)
+        color_spec = color_spec.evolve(source_vector=csv, color_vector=cv)
     else:
         cax = _scatter_points(
             ax,
@@ -1465,7 +1466,7 @@ def _render_points(
             fig_params=fig_params,
             default_reduction=_default_reduction,
         )
-        color_spec = color_spec.with_source_vector(csv).with_color_vector(cv)
+        color_spec = color_spec.evolve(source_vector=csv, color_vector=cv)
 
     elif method == "matplotlib":
         # update axis limits if plot was empty before (necessary if datashader comes after)
@@ -2319,7 +2320,12 @@ def _render_labels(
             render_params,
             x=xy[:, 0],
             y=xy[:, 1],
-            color_spec=ColorSpec(color_spec.colortype, point_color_source_vector, point_color_vector),
+            # point colours are derived fresh; classify by source so the spec stays self-consistent
+            color_spec=ColorSpec(
+                "categorical" if point_color_source_vector is not None else "continuous",
+                point_color_source_vector,
+                point_color_vector,
+            ),
             norm=render_params.cmap_params.fresh_norm(),  # ax.scatter autoscales in place; don't mutate the shared norm
             na_color=na_color,
             adata=table if table_name is not None else None,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -670,7 +670,6 @@ def _render_shapes(
         coordinate_system=coordinate_system,
     )
     colortype = color_spec.colortype
-    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     col_for_outline_color = render_params.col_for_outline_color
     outline_table_name = render_params.outline_table_name
@@ -724,15 +723,18 @@ def _render_shapes(
                 _n_shapes,
             )
 
-    _warn_groups(groups, colortype, color_source_vector, col_for_color)
+    _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
 
     # When groups are specified, filter out non-matching elements by default.
     # Only show non-matching elements if the user explicitly sets na_color.
     _na = render_params.cmap_params.na_color
-    if groups is not None and color_source_vector is not None and (_na.default_color_set or _na.is_fully_transparent()):
-        keep, color_source_vector, color_vector = _filter_groups_transparent_na(
-            groups, color_source_vector, color_vector
-        )
+    if (
+        groups is not None
+        and color_spec.source_vector is not None
+        and (_na.default_color_set or _na.is_fully_transparent())
+    ):
+        keep = color_spec.source_vector.isin(groups)
+        color_spec = color_spec.filter(keep)
         shapes = shapes[keep].reset_index(drop=True)
         if len(shapes) == 0:
             return
@@ -742,7 +744,9 @@ def _render_shapes(
                 outline_color_vector, outline_color_source_vector, keep
             )
 
-    color_vector = _maybe_apply_transfunc(colortype, color_vector, render_params.transfunc)
+    # carrier pipeline done; unpack the final vectors for the read/draw phase below
+    color_spec = color_spec.apply_transfunc(render_params.transfunc)
+    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     norm = render_params.cmap_params.fresh_norm()
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -33,6 +33,7 @@ from xarray import DataTree
 
 from spatialdata_plot._logging import _log_context, logger
 from spatialdata_plot.pl._color import (
+    ColorType,
     _align_outline_vector_to_length,
     _apply_mask_to_outline_vectors,
     _color_vector_to_rgba,
@@ -42,7 +43,7 @@ from spatialdata_plot.pl._color import (
     _maybe_set_colors,
     _prepare_cmap_norm,
     _resolve_continuous_norm,
-    _set_color_source_vec,
+    resolve_color,
 )
 from spatialdata_plot.pl._datashader import (
     _ax_show_and_transform,
@@ -181,11 +182,11 @@ def _reparse_points(
 
 def _warn_groups_ignored_continuous(
     groups: str | list[str] | None,
-    color_source_vector: pd.Categorical | None,
+    colortype: ColorType,
     col_for_color: str | None,
 ) -> None:
     """Warn when ``groups`` is set but coloring is continuous (no categorical source)."""
-    if groups is not None and color_source_vector is None and col_for_color is not None:
+    if groups is not None and colortype == "continuous" and col_for_color is not None:
         logger.warning(
             f"`groups` is ignored when coloring by continuous column '{col_for_color}'. "
             "`groups` filters categories of the column specified via `color`; "
@@ -264,26 +265,24 @@ def _warn_missing_groups(
 
 def _warn_groups(
     groups: str | list[str] | None,
+    colortype: ColorType,
     color_source_vector: pd.Categorical | None,
     col_for_color: str | None,
 ) -> None:
     """Emit the two groups-related warnings every ``_render_*`` preamble shares."""
-    _warn_groups_ignored_continuous(groups, color_source_vector, col_for_color)
-    if groups is not None and color_source_vector is not None:
+    _warn_groups_ignored_continuous(groups, colortype, col_for_color)
+    # behaviour-preserving: `color_source_vector is not None` == colortype != "continuous"
+    if groups is not None and colortype != "continuous":
         _warn_missing_groups(groups, color_source_vector, col_for_color)
 
 
 def _maybe_apply_transfunc(
-    color_source_vector: pd.Categorical | None,
+    colortype: ColorType,
     color_vector: Any,
     transfunc: abc.Callable[[Any], Any] | None,
 ) -> Any:
-    """Apply ``transfunc`` to a continuous ``color_vector``; no-op when categorical or unset.
-
-    ``color_source_vector is None`` marks continuous coloring (it is the materialized categorical
-    source otherwise), so the transform only runs on continuous values.
-    """
-    if color_source_vector is None and transfunc is not None:
+    """Apply ``transfunc`` to a continuous ``color_vector``; no-op when categorical/none or unset."""
+    if colortype == "continuous" and transfunc is not None:
         return transfunc(color_vector)
     return color_vector
 
@@ -374,6 +373,7 @@ def _add_legend_and_colorbar(
     fig_params: FigParams,
     adata: AnnData | None,
     col_for_color: str | None,
+    colortype: ColorType,
     color_source_vector: pd.Series | None,
     color_vector: Any,
     palette: ListedColormap | list[str] | None,
@@ -387,14 +387,12 @@ def _add_legend_and_colorbar(
     outline_color_source_vector: pd.Series | None = None,
     outline_color_vector: Any | None = None,
     outline_cmap_params: CmapParams | None = None,
-    is_continuous_override: bool | None = None,
     na_in_legend_override: bool | None = None,
 ) -> None:
     """Add legend and colorbar decorations if the color vector warrants them.
 
-    ``is_continuous_override`` / ``na_in_legend_override`` let labels supply its renderer-specific
-    values (it tracks ``categorical`` separately and adjusts ``na_in_legend`` for groups) while sharing
-    this body; when ``None`` the shapes/points defaults apply.
+    A continuous colorbar is requested for ``colortype == "continuous"``; ``na_in_legend_override``
+    lets labels adjust ``na_in_legend`` for groups while sharing this body.
     """
     fill_has_decorations = _want_decorations(color_vector, na_color) and col_for_color is not None
     outline_has_decorations = outline_col_for_color is not None and (
@@ -413,9 +411,7 @@ def _add_legend_and_colorbar(
     wants_colorbar = _should_request_colorbar(
         colorbar,
         has_mappable=cax is not None,
-        is_continuous=is_continuous_override
-        if is_continuous_override is not None
-        else (col_for_color is not None and color_source_vector is None),
+        is_continuous=col_for_color is not None and colortype == "continuous",
     )
 
     if fill_has_decorations:
@@ -660,7 +656,7 @@ def _render_shapes(
     trans, trans_data = _prepare_transformation(sdata_filt.shapes[element], coordinate_system)
 
     # get color vector (categorical or continuous)
-    color_source_vector, color_vector, _ = _set_color_source_vec(
+    _spec = resolve_color(
         sdata=sdata_filt,
         element=sdata_filt[element],
         element_name=element,
@@ -673,8 +669,11 @@ def _render_shapes(
         table_layer=table_layer,
         coordinate_system=coordinate_system,
     )
+    colortype = _spec.colortype
+    color_source_vector, color_vector = _spec.source_vector, _spec.color_vector
 
-    values_are_categorical = color_source_vector is not None
+    # behaviour-preserving: `color_source_vector is not None` == colortype != "continuous"
+    values_are_categorical = colortype != "continuous"
 
     col_for_outline_color = render_params.col_for_outline_color
     outline_table_name = render_params.outline_table_name
@@ -694,7 +693,7 @@ def _render_shapes(
             # so the per-shape outline vector length matches the rendered shapes.
             if table_name is None:
                 sdata_filt[element] = shapes = joined_outline_element
-        outline_color_source_vector, outline_color_vector, _ = _set_color_source_vec(
+        _outline_spec = resolve_color(
             sdata=sdata_filt,
             element=sdata_filt[element],
             element_name=element,
@@ -707,6 +706,7 @@ def _render_shapes(
             table_layer=table_layer,
             coordinate_system=coordinate_system,
         )
+        outline_color_source_vector, outline_color_vector = _outline_spec.source_vector, _outline_spec.color_vector
         # Cross-table case: if fill and outline tables differ and the outline table does
         # not annotate every row of the (fill-joined) element, the vector length will
         # differ from the rendered element row count. Warn + align so per-shape lookup stays
@@ -724,7 +724,7 @@ def _render_shapes(
                 _n_shapes,
             )
 
-    _warn_groups(groups, color_source_vector, col_for_color)
+    _warn_groups(groups, colortype, color_source_vector, col_for_color)
 
     # When groups are specified, filter out non-matching elements by default.
     # Only show non-matching elements if the user explicitly sets na_color.
@@ -742,7 +742,7 @@ def _render_shapes(
                 outline_color_vector, outline_color_source_vector, keep
             )
 
-    color_vector = _maybe_apply_transfunc(color_source_vector, color_vector, render_params.transfunc)
+    color_vector = _maybe_apply_transfunc(colortype, color_vector, render_params.transfunc)
 
     norm = render_params.cmap_params.fresh_norm()
 
@@ -796,6 +796,7 @@ def _render_shapes(
             y=xy[:, 1],
             color_vector=color_vector,
             color_source_vector=color_source_vector,
+            colortype=colortype,
             norm=norm,
             na_color=render_params.cmap_params.na_color,
             adata=table,
@@ -1046,6 +1047,7 @@ def _render_shapes(
         fig_params=fig_params,
         adata=table,
         col_for_color=col_for_color,
+        colortype=colortype,
         color_source_vector=color_source_vector,
         color_vector=color_vector,
         palette=palette,
@@ -1130,6 +1132,7 @@ def _render_centroids_as_points(
     y: Any,
     color_vector: Any,
     color_source_vector: pd.Series | None,
+    colortype: ColorType,
     norm: Normalize | None,
     na_color: Any,
     adata: AnnData | None,
@@ -1190,6 +1193,7 @@ def _render_centroids_as_points(
         fig_params=fig_params,
         adata=adata,
         col_for_color=col_for_color,
+        colortype=colortype,
         color_source_vector=color_source_vector,
         color_vector=color_vector,
         palette=palette,
@@ -1441,7 +1445,7 @@ def _render_points(
         else None
     )
 
-    color_source_vector, color_vector, _ = _set_color_source_vec(
+    _spec = resolve_color(
         sdata=sdata_filt,
         element=color_element,
         element_name=element,
@@ -1456,6 +1460,8 @@ def _render_points(
         coordinate_system=coordinate_system,
         preloaded_color_data=_preloaded,
     )
+    colortype = _spec.colortype
+    color_source_vector, color_vector = _spec.source_vector, _spec.color_vector
 
     if added_color_from_table and col_for_color is not None:
         _reparse_points(
@@ -1467,7 +1473,7 @@ def _render_points(
             col_for_color,
         )
 
-    _warn_groups(groups, color_source_vector, col_for_color)
+    _warn_groups(groups, colortype, color_source_vector, col_for_color)
 
     # When groups are specified, filter out non-matching elements by default.
     # Only show non-matching elements if the user explicitly sets na_color.
@@ -1484,7 +1490,7 @@ def _render_points(
         adata = adata[keep]
         _reparse_points(sdata_filt, element, points, transformation_in_cs, coordinate_system, col_for_color)
 
-    color_vector = _maybe_apply_transfunc(color_source_vector, color_vector, render_params.transfunc)
+    color_vector = _maybe_apply_transfunc(colortype, color_vector, render_params.transfunc)
 
     trans, trans_data = _prepare_transformation(sdata.points[element], coordinate_system, ax)
 
@@ -1562,6 +1568,7 @@ def _render_points(
         fig_params=fig_params,
         adata=adata,
         col_for_color=col_for_color,
+        colortype=colortype,
         color_source_vector=color_source_vector,
         color_vector=color_vector,
         palette=None,
@@ -2274,7 +2281,7 @@ def _render_labels(
         if col_for_color is None and render_params.color is not None
         else render_params.cmap_params.na_color
     )
-    color_source_vector, color_vector, categorical = _set_color_source_vec(
+    _spec = resolve_color(
         sdata=sdata_filt,
         element=label,
         element_name=element,
@@ -2288,6 +2295,9 @@ def _render_labels(
         render_type="labels",
         coordinate_system=coordinate_system,
     )
+    colortype = _spec.colortype
+    color_source_vector, color_vector = _spec.source_vector, _spec.color_vector
+    categorical = colortype == "categorical"
 
     # Outline color lookup must run BEFORE any masking so the returned vector aligns to
     # the original instance_id. The same masks applied to fill below are then applied
@@ -2297,7 +2307,7 @@ def _render_labels(
     outline_color_source_vector: pd.Series | None = None
     outline_color_vector: Any = None
     if col_for_outline_color is not None:
-        outline_color_source_vector, outline_color_vector, _ = _set_color_source_vec(
+        _outline_spec = resolve_color(
             sdata=sdata_filt,
             element=label,
             element_name=element,
@@ -2311,6 +2321,7 @@ def _render_labels(
             render_type="labels",
             coordinate_system=coordinate_system,
         )
+        outline_color_source_vector, outline_color_vector = _outline_spec.source_vector, _outline_spec.color_vector
         # Align to instance_id so the rasterize/groups masks (computed against
         # instance_id) can be applied without IndexError when the outline table
         # annotates a subset of the labels.
@@ -2338,7 +2349,7 @@ def _render_labels(
                 outline_color_vector, outline_color_source_vector, mask
             )
 
-    _warn_groups(groups, color_source_vector, col_for_color)
+    _warn_groups(groups, colortype, color_source_vector, col_for_color)
 
     # When groups are specified, zero out non-matching label IDs so they render as background.
     # Only show non-matching labels if the user explicitly sets na_color.
@@ -2364,7 +2375,7 @@ def _render_labels(
                 outline_color_vector, outline_color_source_vector, keep_vec
             )
 
-    color_vector = _maybe_apply_transfunc(color_source_vector, color_vector, render_params.transfunc)
+    color_vector = _maybe_apply_transfunc(colortype, color_vector, render_params.transfunc)
 
     if render_params.as_points:
         # Fast mode: one dot per label at its centroid. Compute on the *rendered* raster (already
@@ -2408,6 +2419,7 @@ def _render_labels(
             y=xy[:, 1],
             color_vector=point_color_vector,
             color_source_vector=point_color_source_vector,
+            colortype=colortype,
             norm=render_params.cmap_params.fresh_norm(),  # ax.scatter autoscales in place; don't mutate the shared norm
             na_color=na_color,
             adata=table if table_name is not None else None,
@@ -2507,14 +2519,14 @@ def _render_labels(
     else:
         raise ValueError("Parameters 'fill_alpha' and 'outline_alpha' cannot both be 0.")
 
-    # Labels track `categorical` separately and tweak `na_in_legend` for groups, so pass those through
-    # the overrides; everything else (fill/outline legends, colorbar request, auto-title) is shared.
+    # Labels tweak na_in_legend for groups (via na_in_legend_override); everything else is shared.
     _add_legend_and_colorbar(
         ax=ax,
         cax=cax,
         fig_params=fig_params,
         adata=table,
         col_for_color=col_for_color,
+        colortype=colortype,
         color_source_vector=color_source_vector,
         color_vector=color_vector,
         palette=palette,
@@ -2528,7 +2540,6 @@ def _render_labels(
         outline_color_source_vector=outline_color_source_vector,
         outline_color_vector=outline_color_vector,
         outline_cmap_params=render_params.cmap_params,
-        is_continuous_override=col_for_color is not None and color_source_vector is None and not categorical,
         na_in_legend_override=(legend_params.na_in_legend if groups is None else len(groups) == len(set(color_vector))),
     )
 

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -180,11 +180,11 @@ def _reparse_points(
 
 def _warn_groups_ignored_continuous(
     groups: str | list[str] | None,
-    colortype: ColorType,
+    color_spec: ColorSpec,
     col_for_color: str | None,
 ) -> None:
     """Warn when ``groups`` is set but coloring is continuous (no categorical source)."""
-    if groups is not None and colortype == "continuous" and col_for_color is not None:
+    if groups is not None and color_spec.is_continuous and col_for_color is not None:
         logger.warning(
             f"`groups` is ignored when coloring by continuous column '{col_for_color}'. "
             "`groups` filters categories of the column specified via `color`; "
@@ -204,22 +204,21 @@ def _reject_continuous_color_under_density(
     sdata_filt: sd.SpatialData,
     element: str,
     col_for_color: str | None,
-    colortype: ColorType,
-    color_vector: Any,
+    color_spec: ColorSpec,
 ) -> None:
     """Raise before any materialization if density+continuous-color was requested.
 
-    Only ``continuous`` coloring is rejected; categorical and none are fine. When the colortype
-    is not yet decisive we read the dtype from the dask source (points element column) or the
-    pre-computed color vector — neither forces a ``.compute()``.
+    Only ``continuous`` coloring is rejected; categorical and none are fine. We read the dtype from
+    the dask source (points element column) or the pre-computed color vector — neither forces a
+    ``.compute()``.
     """
-    if col_for_color is None or colortype != "continuous":
+    if col_for_color is None or not color_spec.is_continuous:
         return
     points_columns = sdata_filt.points[element].columns
     if col_for_color in points_columns:
         dtype = sdata_filt.points[element][col_for_color].dtype
     else:
-        dtype = getattr(color_vector, "dtype", None)
+        dtype = getattr(color_spec.color_vector, "dtype", None)
     if dtype is None or _is_categorical_like_dtype(dtype):
         return
     raise ValueError(
@@ -262,15 +261,14 @@ def _warn_missing_groups(
 
 def _warn_groups(
     groups: str | list[str] | None,
-    colortype: ColorType,
-    color_source_vector: pd.Categorical | None,
+    color_spec: ColorSpec,
     col_for_color: str | None,
 ) -> None:
     """Emit the two groups-related warnings every ``_render_*`` preamble shares."""
-    _warn_groups_ignored_continuous(groups, colortype, col_for_color)
+    _warn_groups_ignored_continuous(groups, color_spec, col_for_color)
     # only a categorical source has `.categories`; the none state (na-array source) must not reach it
-    if groups is not None and colortype == "categorical":
-        _warn_missing_groups(groups, color_source_vector, col_for_color)
+    if groups is not None and color_spec.is_categorical:
+        _warn_missing_groups(groups, color_spec.source_vector, col_for_color)
 
 
 def _split_colorbar_params(
@@ -684,13 +682,11 @@ def _render_shapes(
             )
             outline_color_spec = outline_color_spec.align_to_length(_n_shapes, render_params.cmap_params.na_color)
 
-    _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
+    _warn_groups(groups, color_spec, col_for_color)
 
-    # When groups are specified, filter out non-matching elements by default.
-    # Only show non-matching elements if the user explicitly sets na_color.
-    _na = render_params.cmap_params.na_color
-    if groups is not None and color_spec.is_categorical and (_na.default_color_set or _na.is_fully_transparent()):
-        keep = color_spec.source_vector.isin(groups)
+    # groups filters to matching categories by default; a visible na_color keeps non-matching rows.
+    keep = color_spec.groups_keep_mask(groups, render_params.cmap_params.na_color)
+    if keep is not None:
         color_spec = color_spec.filter(keep)
         shapes = shapes[keep].reset_index(drop=True)
         if len(shapes) == 0:
@@ -862,7 +858,7 @@ def _render_shapes(
 
             transformed_element[col_for_color] = color_vector if color_source_vector is None else color_source_vector
         # Render shapes with datashader
-        color_by_categorical = col_for_color is not None and color_source_vector is not None
+        color_by_categorical = color_spec.is_categorical
         if color_by_categorical:
             cat_series = transformed_element[col_for_color]
             if not isinstance(cat_series.dtype, pd.CategoricalDtype):
@@ -1430,16 +1426,13 @@ def _render_points(
             col_for_color,
         )
 
-    _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
+    _warn_groups(groups, color_spec, col_for_color)
 
-    # When groups are specified, filter out non-matching elements by default.
-    # Only show non-matching elements if the user explicitly sets na_color.
-    _na = render_params.cmap_params.na_color
-    if groups is not None and color_spec.is_categorical and (_na.default_color_set or _na.is_fully_transparent()):
-        keep = color_spec.source_vector.isin(groups)
+    # groups filters to matching categories by default; a visible na_color keeps non-matching rows.
+    keep = color_spec.groups_keep_mask(groups, render_params.cmap_params.na_color)
+    if keep is not None:
         color_spec = color_spec.filter(keep)
-        n_points = int(keep.sum())
-        if n_points == 0:
+        if int(keep.sum()) == 0:
             return
         # filter the materialized points, adata, and re-register in sdata_filt
         points = points[keep].reset_index(drop=True)
@@ -1457,7 +1450,7 @@ def _render_points(
 
     if render_params.density:
         method = "datashader"
-        _reject_continuous_color_under_density(sdata_filt, element, col_for_color, colortype, color_vector)
+        _reject_continuous_color_under_density(sdata_filt, element, col_for_color, color_spec)
     elif method is None:
         method = "datashader" if n_points > 10000 else "matplotlib"
 
@@ -2253,7 +2246,6 @@ def _render_labels(
         coordinate_system=coordinate_system,
     )
     colortype = color_spec.colortype
-    categorical = color_spec.is_categorical
 
     # Outline color lookup must run BEFORE any masking so the returned vector aligns to
     # the original instance_id. The same masks applied to fill below are then applied
@@ -2291,18 +2283,12 @@ def _render_labels(
         if outline_color_spec is not None:
             outline_color_spec = outline_color_spec.filter(mask)
 
-    _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
+    _warn_groups(groups, color_spec, col_for_color)
 
     # When groups are specified, zero out non-matching label IDs so they render as background.
     # Only show non-matching labels if the user explicitly sets na_color.
-    _na = render_params.cmap_params.na_color
-    if (
-        groups is not None
-        and categorical
-        and color_spec.source_vector is not None
-        and (_na.default_color_set or _na.is_fully_transparent())
-    ):
-        keep_vec = color_spec.source_vector.isin(groups)
+    keep_vec = color_spec.groups_keep_mask(groups, render_params.cmap_params.na_color)
+    if keep_vec is not None:
         matching_ids = instance_id[keep_vec]
         keep_mask = np.isin(label.values, matching_ids)
         label = label.copy()
@@ -2400,8 +2386,10 @@ def _render_labels(
         cax = ax.imshow(
             labels,
             rasterized=True,
-            cmap=None if categorical else render_params.cmap_params.cmap,
-            norm=None if categorical else _resolve_continuous_norm(color_vector, render_params.cmap_params),
+            cmap=None if color_spec.is_categorical else render_params.cmap_params.cmap,
+            norm=None
+            if color_spec.is_categorical
+            else _resolve_continuous_norm(color_vector, render_params.cmap_params),
             alpha=alpha,
             origin="lower",
             zorder=render_params.zorder,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -2304,7 +2304,6 @@ def _render_labels(
         coordinate_system=coordinate_system,
     )
     colortype = color_spec.colortype
-    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
     categorical = color_spec.is_categorical
 
     # Outline color lookup must run BEFORE any masking so the returned vector aligns to
@@ -2348,19 +2347,13 @@ def _render_labels(
         mask = np.isin(instance_id, unique_labels)
         instance_id = instance_id[mask]
         if col_for_color is not None:
-            color_vector = color_vector[mask]
-            if isinstance(color_vector.dtype, pd.CategoricalDtype):
-                color_vector = color_vector.remove_unused_categories()
-                assert color_source_vector is not None  # noqa: S101
-                color_source_vector = color_source_vector[mask]
-            else:
-                assert color_source_vector is None  # noqa: S101
+            color_spec = color_spec.filter(mask)
         if outline_color_vector is not None:
             outline_color_vector, outline_color_source_vector = _apply_mask_to_outline_vectors(
                 outline_color_vector, outline_color_source_vector, mask
             )
 
-    _warn_groups(groups, colortype, color_source_vector, col_for_color)
+    _warn_groups(groups, colortype, color_spec.source_vector, col_for_color)
 
     # When groups are specified, zero out non-matching label IDs so they render as background.
     # Only show non-matching labels if the user explicitly sets na_color.
@@ -2368,25 +2361,24 @@ def _render_labels(
     if (
         groups is not None
         and categorical
-        and color_source_vector is not None
+        and color_spec.source_vector is not None
         and (_na.default_color_set or _na.is_fully_transparent())
     ):
-        keep_vec = color_source_vector.isin(groups)
+        keep_vec = color_spec.source_vector.isin(groups)
         matching_ids = instance_id[keep_vec]
         keep_mask = np.isin(label.values, matching_ids)
         label = label.copy()
         label.values[~keep_mask] = 0
         instance_id = instance_id[keep_vec]
-        color_source_vector = color_source_vector[keep_vec]
-        color_vector = color_vector[keep_vec]
-        if isinstance(color_vector.dtype, pd.CategoricalDtype):
-            color_vector = color_vector.remove_unused_categories()
+        color_spec = color_spec.filter(keep_vec)
         if outline_color_vector is not None:
             outline_color_vector, outline_color_source_vector = _apply_mask_to_outline_vectors(
                 outline_color_vector, outline_color_source_vector, keep_vec
             )
 
-    color_vector = _maybe_apply_transfunc(colortype, color_vector, render_params.transfunc)
+    # carrier pipeline done; unpack the final vectors for the read/draw phase below
+    color_spec = color_spec.apply_transfunc(render_params.transfunc)
+    color_source_vector, color_vector = color_spec.source_vector, color_spec.color_vector
 
     if render_params.as_points:
         # Fast mode: one dot per label at its centroid. Compute on the *rendered* raster (already

--- a/tests/pl/test_render_labels.py
+++ b/tests/pl/test_render_labels.py
@@ -521,6 +521,25 @@ def test_transfunc_is_applied_for_continuous_labels(sdata_blobs: SpatialData):
     assert called, "transfunc was not called for continuous labels data"
 
 
+def test_render_labels_all_nan_color_renders_under_rasterize(sdata_blobs: SpatialData):
+    # Regression: an all-NaN color column is the "none" colortype (na-array source, not None).
+    # Under default rasterize the per-instance mask path used to trip an
+    # `assert color_source_vector is None`; it must now just render.
+    labels_name = "blobs_labels"
+    instances = get_element_instances(sdata_blobs[labels_name])
+    n_obs = len(instances)
+    adata = AnnData(np.zeros((n_obs, 1)))
+    adata.obs["instance_id"] = instances.values
+    adata.obs["nanvals"] = np.full(n_obs, np.nan)
+    adata.obs["region"] = labels_name
+    sdata_blobs["label_table"] = TableModel.parse(
+        adata=adata, region_key="region", instance_key="instance_id", region=labels_name
+    )
+    fig, ax = plt.subplots()
+    sdata_blobs.pl.render_labels(labels_name, color="nanvals", table_name="label_table").pl.show(ax=ax)
+    plt.close(fig)
+
+
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_render_labels_rejects_float_dtype(dtype):
     # Regression test for #606: float-dtype labels must raise a clear

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -24,6 +24,7 @@ from spatialdata.transformations._utils import _set_transformations
 
 import spatialdata_plot  # noqa: F401
 from spatialdata_plot._logging import logger, logger_no_warns, logger_warns
+from spatialdata_plot.pl._color import ColorSpec
 from spatialdata_plot.pl._datashader import (
     _build_datashader_color_key,
     _ds_aggregate,
@@ -904,14 +905,16 @@ def test_groups_warns_when_continuous_points(sdata_blobs: SpatialData, caplog):
 
 def test_warn_groups_ignored_continuous_emits(caplog):
     """_warn_groups_ignored_continuous emits when groups is set but data is continuous."""
+    spec = ColorSpec("continuous", None, np.array([1.0, 2.0]))
     with logger_warns(caplog, logger, match="ignored.*continuous"):
-        _warn_groups_ignored_continuous(["A"], "continuous", "my_col")
+        _warn_groups_ignored_continuous(["A"], spec, "my_col")
 
 
 def test_warn_groups_ignored_continuous_silent_for_categorical(caplog):
     """No warning when coloring is categorical."""
+    spec = ColorSpec("categorical", pd.Categorical(["a", "b"]), np.array(["#ff0000ff", "#00ff00ff"], dtype=object))
     with logger_no_warns(caplog, logger, match="ignored"):
-        _warn_groups_ignored_continuous(["A"], "categorical", "cat_col")
+        _warn_groups_ignored_continuous(["A"], spec, "cat_col")
 
 
 def test_color_key_warns_on_short_color_vector(caplog):

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -1029,6 +1029,18 @@ def test_render_points_color_by_z_data_column():
         plt.close(fig)
 
 
+def test_render_points_all_nan_color_with_groups_does_not_crash():
+    # Regression: all-NaN color is the "none" colortype; the groups preamble must not call
+    # .isin on the na-array source (same none-state class as the labels/shapes crashes).
+    pts = PointsModel.parse(pd.DataFrame({"x": [1.0, 2.0, 3.0], "y": [1.0, 2.0, 3.0], "nanvals": [np.nan] * 3}))
+    sdata = SpatialData(points={"p": pts})
+    fig, ax = plt.subplots()
+    try:
+        sdata.pl.render_points("p", color="nanvals", groups=["a"]).pl.show(ax=ax)
+    finally:
+        plt.close(fig)
+
+
 def test_render_points_color_by_z_with_extra_columns():
     # regression test for #615
     pts = PointsModel.parse(

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -905,13 +905,13 @@ def test_groups_warns_when_continuous_points(sdata_blobs: SpatialData, caplog):
 def test_warn_groups_ignored_continuous_emits(caplog):
     """_warn_groups_ignored_continuous emits when groups is set but data is continuous."""
     with logger_warns(caplog, logger, match="ignored.*continuous"):
-        _warn_groups_ignored_continuous(["A"], None, "my_col")
+        _warn_groups_ignored_continuous(["A"], "continuous", "my_col")
 
 
 def test_warn_groups_ignored_continuous_silent_for_categorical(caplog):
-    """No warning when color_source_vector is present (categorical)."""
+    """No warning when coloring is categorical."""
     with logger_no_warns(caplog, logger, match="ignored"):
-        _warn_groups_ignored_continuous(["A"], pd.Categorical(["A", "B"]), "cat_col")
+        _warn_groups_ignored_continuous(["A"], "categorical", "cat_col")
 
 
 def test_color_key_warns_on_short_color_vector(caplog):

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -1132,6 +1132,15 @@ def test_render_shapes_all_nan_outline_color_does_not_crash(sdata_blobs_shapes_a
     plt.close(fig)
 
 
+def test_render_shapes_all_nan_color_datashader_does_not_crash(sdata_blobs_shapes_annotated: SpatialData):
+    # Regression: all-NaN color is the "none" colortype; the datashader path must route it through
+    # the categorical color-key (na_color), not the numeric reduction (which rejects the na column).
+    sdata_blobs_shapes_annotated["blobs_polygons"]["nanvals"] = [np.nan] * 5
+    fig, ax = plt.subplots()
+    sdata_blobs_shapes_annotated.pl.render_shapes("blobs_polygons", color="nanvals", method="datashader").pl.show(ax=ax)
+    plt.close(fig)
+
+
 def test_render_shapes_all_nan_color_with_groups_does_not_crash(sdata_blobs_shapes_annotated: SpatialData):
     # Regression: all-NaN color is the "none" colortype (na-array source, not categorical); the
     # groups preamble must not feed it to _warn_missing_groups, which reads `.categories`.

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -1121,6 +1121,17 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
         self._as_points(sdata_blobs, "datashader").pl.show()
 
 
+def test_render_shapes_all_nan_outline_color_does_not_crash(sdata_blobs_shapes_annotated: SpatialData):
+    # Regression: an all-NaN outline column is the "none" colortype (na-array source); the outline
+    # legend path must not call .remove_unused_categories() on that ndarray.
+    sdata_blobs_shapes_annotated["blobs_polygons"]["nanout"] = [np.nan] * 5
+    fig, ax = plt.subplots()
+    sdata_blobs_shapes_annotated.pl.render_shapes(
+        "blobs_polygons", outline_alpha=1, outline_width=3, outline_color="nanout"
+    ).pl.show(ax=ax)
+    plt.close(fig)
+
+
 def test_render_shapes_all_nan_color_with_groups_does_not_crash(sdata_blobs_shapes_annotated: SpatialData):
     # Regression: all-NaN color is the "none" colortype (na-array source, not categorical); the
     # groups preamble must not feed it to _warn_missing_groups, which reads `.categories`.

--- a/tests/pl/test_render_shapes.py
+++ b/tests/pl/test_render_shapes.py
@@ -1121,6 +1121,15 @@ class TestShapes(PlotTester, metaclass=PlotTesterMeta):
         self._as_points(sdata_blobs, "datashader").pl.show()
 
 
+def test_render_shapes_all_nan_color_with_groups_does_not_crash(sdata_blobs_shapes_annotated: SpatialData):
+    # Regression: all-NaN color is the "none" colortype (na-array source, not categorical); the
+    # groups preamble must not feed it to _warn_missing_groups, which reads `.categories`.
+    sdata_blobs_shapes_annotated["blobs_polygons"]["nanvals"] = [np.nan] * 5
+    fig, ax = plt.subplots()
+    sdata_blobs_shapes_annotated.pl.render_shapes("blobs_polygons", color="nanvals", groups=["a"]).pl.show(ax=ax)
+    plt.close(fig)
+
+
 def test_gene_symbols_auto_detect_table(sdata_blobs: SpatialData):
     """gene_symbols resolves correctly without explicit table_name (#247)."""
     sdata_blobs["table"].obs["region"] = pd.Categorical(["blobs_circles"] * sdata_blobs["table"].n_obs)

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -1027,6 +1027,18 @@ class TestColorSpecTransforms:
         assert list(out.color_vector[-2:]) == [na.get_hex_with_alpha()] * 2
         assert pd.isna(out.source_vector[-2:]).all()  # padded rows carry no category
 
+    def test_align_to_length_pads_none_state_with_na(self):
+        # the trap: a `none` spec has a non-None na *array* source (not a Categorical); padding it
+        # must not take the categorical `.categories` branch
+        from spatialdata_plot.pl._color import ColorSpec
+
+        na = Color("#abcdefff")
+        na_hex = na.get_hex_with_alpha()
+        spec = ColorSpec("none", np.array([na_hex, na_hex], dtype=object), np.array([na_hex, na_hex], dtype=object))
+        out = spec.align_to_length(4, na)
+        assert len(out.color_vector) == len(out.source_vector) == 4
+        assert list(out.color_vector) == [na_hex] * 4
+
     def test_align_to_length_pads_continuous_with_nan(self):
         out = self._cont_spec().align_to_length(6, Color())
         assert out.source_vector is None

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -930,23 +930,36 @@ class TestResolveColor:
             cmap_params=self._cmap_params(),
         )
 
+    @staticmethod
+    def _assert_predicates(spec, expected: str):
+        # exactly one predicate true, matching colortype
+        assert (spec.is_categorical, spec.is_continuous, spec.is_none) == (
+            expected == "categorical",
+            expected == "continuous",
+            expected == "none",
+        )
+
     def test_no_value_is_none_colortype(self, sdata_blobs_shapes_annotated: SpatialData):
         spec = self._resolve(sdata_blobs_shapes_annotated, None)
         assert spec.colortype == "none"
         assert spec.source_vector is not None  # na array, not None
+        self._assert_predicates(spec, "none")
 
     def test_all_nan_column_is_none_colortype(self, sdata_blobs_shapes_annotated: SpatialData):
         sdata_blobs_shapes_annotated["blobs_polygons"]["nanvals"] = [np.nan] * 5
         spec = self._resolve(sdata_blobs_shapes_annotated, "nanvals")
         assert spec.colortype == "none"
+        self._assert_predicates(spec, "none")
 
     def test_numeric_column_is_continuous(self, sdata_blobs_shapes_annotated: SpatialData):
         spec = self._resolve(sdata_blobs_shapes_annotated, "value")  # fixture's [1..5]
         assert spec.colortype == "continuous"
         assert spec.source_vector is None  # the continuous marker
+        self._assert_predicates(spec, "continuous")
 
     def test_categorical_column_is_categorical(self, sdata_blobs_shapes_annotated: SpatialData):
         sdata_blobs_shapes_annotated["blobs_polygons"]["cat"] = ["a", "b", "a", "b", "a"]
         spec = self._resolve(sdata_blobs_shapes_annotated, "cat")
         assert spec.colortype == "categorical"
         assert isinstance(spec.source_vector, pd.Categorical)
+        self._assert_predicates(spec, "categorical")

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -881,12 +881,35 @@ class TestResolveContinuousNorm:
         norm = _resolve_continuous_norm(np.array([np.nan, np.nan]), self._params())
         assert (norm.vmin, norm.vmax) == (0.0, 1.0)
 
-    def test_degenerate_range_is_not_expanded(self):
-        # behavior-preserving: a single distinct value stays degenerate (no invented +/-0.5)
+    def test_degenerate_range_resets_to_unit_interval(self):
+        # a single distinct value collapses the colormap onto its floor; reset to [0, 1] (#503)
         from spatialdata_plot.pl._color import _resolve_continuous_norm
 
         norm = _resolve_continuous_norm(np.array([5.0, 5.0, 5.0]), self._params())
+        assert (norm.vmin, norm.vmax) == (0.0, 1.0)
+
+    def test_degenerate_lognorm_is_left_untouched(self):
+        # LogNorm domain excludes 0, so the degenerate reset must not fire for it
+        from matplotlib.colors import LogNorm
+
+        from spatialdata_plot.pl._color import _resolve_continuous_norm
+
+        params = CmapParams(cmap=self._params().cmap, norm=LogNorm(vmin=5.0, vmax=5.0), na_color=Color())
+        norm = _resolve_continuous_norm(np.array([5.0, 5.0]), params)
+        assert isinstance(norm, LogNorm)
         assert (norm.vmin, norm.vmax) == (5.0, 5.0)
+
+    def test_preserves_norm_subclass_and_derives_range(self):
+        # regression: a LogNorm must stay a LogNorm (not be linearized) while still getting its
+        # vmin/vmax filled from the data range
+        from matplotlib.colors import LogNorm
+
+        from spatialdata_plot.pl._color import _resolve_continuous_norm
+
+        params = CmapParams(cmap=self._params().cmap, norm=LogNorm(vmin=None, vmax=None), na_color=Color())
+        norm = _resolve_continuous_norm(np.array([1.0, 10.0, 1000.0]), params)
+        assert isinstance(norm, LogNorm)
+        assert (norm.vmin, norm.vmax) == (1.0, 1000.0)
 
     def test_object_dtype_coerces_color_strings_to_nan(self):
         from spatialdata_plot.pl._color import _resolve_continuous_norm
@@ -930,39 +953,29 @@ class TestResolveColor:
             cmap_params=self._cmap_params(),
         )
 
-    @staticmethod
-    def _assert_predicates(spec, expected: str):
-        # exactly one predicate true, matching colortype
-        assert (spec.is_categorical, spec.is_continuous, spec.is_none) == (
-            expected == "categorical",
-            expected == "continuous",
-            expected == "none",
-        )
-
     def test_no_value_is_none_colortype(self, sdata_blobs_shapes_annotated: SpatialData):
         spec = self._resolve(sdata_blobs_shapes_annotated, None)
         assert spec.colortype == "none"
         assert spec.source_vector is not None  # na array, not None
-        self._assert_predicates(spec, "none")
+        assert (spec.is_categorical, spec.is_continuous, spec.is_none) == (False, False, True)
 
     def test_all_nan_column_is_none_colortype(self, sdata_blobs_shapes_annotated: SpatialData):
         sdata_blobs_shapes_annotated["blobs_polygons"]["nanvals"] = [np.nan] * 5
         spec = self._resolve(sdata_blobs_shapes_annotated, "nanvals")
         assert spec.colortype == "none"
-        self._assert_predicates(spec, "none")
 
     def test_numeric_column_is_continuous(self, sdata_blobs_shapes_annotated: SpatialData):
         spec = self._resolve(sdata_blobs_shapes_annotated, "value")  # fixture's [1..5]
         assert spec.colortype == "continuous"
         assert spec.source_vector is None  # the continuous marker
-        self._assert_predicates(spec, "continuous")
+        assert (spec.is_categorical, spec.is_continuous, spec.is_none) == (False, True, False)
 
     def test_categorical_column_is_categorical(self, sdata_blobs_shapes_annotated: SpatialData):
         sdata_blobs_shapes_annotated["blobs_polygons"]["cat"] = ["a", "b", "a", "b", "a"]
         spec = self._resolve(sdata_blobs_shapes_annotated, "cat")
         assert spec.colortype == "categorical"
         assert isinstance(spec.source_vector, pd.Categorical)
-        self._assert_predicates(spec, "categorical")
+        assert (spec.is_categorical, spec.is_continuous, spec.is_none) == (True, False, False)
 
 
 class TestColorSpecTransforms:
@@ -1001,7 +1014,24 @@ class TestColorSpecTransforms:
         assert cat.apply_transfunc(lambda x: x) is cat  # no-op for categorical
         assert cat.apply_transfunc(None) is cat
 
-    def test_with_color_vector_replaces_only_color(self):
-        out = self._cont_spec().with_color_vector(np.array([9.0]))
-        assert list(out.color_vector) == [9.0]
-        assert out.colortype == "continuous" and out.source_vector is None
+    def test_align_to_length_truncates_both_vectors(self):
+        out = self._cat_spec().align_to_length(2, Color())
+        assert list(out.source_vector) == ["a", "b"]
+        assert list(out.color_vector) == ["#ff0000", "#00ff00"]
+
+    def test_align_to_length_pads_categorical_with_na_color_hex(self):
+        # padded rows must carry the na_color hex, not NaN (NaN crashes to_rgba_array)
+        na = Color("#abcdefff")
+        out = self._cat_spec().align_to_length(6, na)
+        assert len(out.color_vector) == len(out.source_vector) == 6
+        assert list(out.color_vector[-2:]) == [na.get_hex_with_alpha()] * 2
+        assert pd.isna(out.source_vector[-2:]).all()  # padded rows carry no category
+
+    def test_align_to_length_pads_continuous_with_nan(self):
+        out = self._cont_spec().align_to_length(6, Color())
+        assert out.source_vector is None
+        assert np.isnan(np.asarray(out.color_vector, dtype=float)[-2:]).all()
+
+    def test_align_to_length_noop_when_already_matching(self):
+        spec = self._cont_spec()
+        assert spec.align_to_length(4, Color()) is spec

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -905,3 +905,48 @@ class TestResolveContinuousNorm:
         b = _resolve_continuous_norm(vals, params)
         assert (a.vmin, a.vmax) == (b.vmin, b.vmax) == (2.0, 7.0)
         assert params.norm.vmin is None and params.norm.vmax is None
+
+
+class TestResolveColor:
+    """resolve_color classifies each _set_color_source_vec return branch into a ColorType (#700)."""
+
+    @staticmethod
+    def _cmap_params() -> CmapParams:
+        from matplotlib import colormaps
+        from matplotlib.colors import Normalize
+
+        return CmapParams(cmap=colormaps["viridis"], norm=Normalize(), na_color=Color())
+
+    def _resolve(self, sdata_blobs_shapes_annotated: SpatialData, value_to_plot: str | None):
+        from spatialdata_plot.pl._color import resolve_color
+
+        element_name = "blobs_polygons"
+        return resolve_color(
+            sdata=sdata_blobs_shapes_annotated,
+            element=sdata_blobs_shapes_annotated[element_name],
+            element_name=element_name,
+            value_to_plot=value_to_plot,
+            na_color=Color(),
+            cmap_params=self._cmap_params(),
+        )
+
+    def test_no_value_is_none_colortype(self, sdata_blobs_shapes_annotated: SpatialData):
+        spec = self._resolve(sdata_blobs_shapes_annotated, None)
+        assert spec.colortype == "none"
+        assert spec.source_vector is not None  # na array, not None
+
+    def test_all_nan_column_is_none_colortype(self, sdata_blobs_shapes_annotated: SpatialData):
+        sdata_blobs_shapes_annotated["blobs_polygons"]["nanvals"] = [np.nan] * 5
+        spec = self._resolve(sdata_blobs_shapes_annotated, "nanvals")
+        assert spec.colortype == "none"
+
+    def test_numeric_column_is_continuous(self, sdata_blobs_shapes_annotated: SpatialData):
+        spec = self._resolve(sdata_blobs_shapes_annotated, "value")  # fixture's [1..5]
+        assert spec.colortype == "continuous"
+        assert spec.source_vector is None  # the continuous marker
+
+    def test_categorical_column_is_categorical(self, sdata_blobs_shapes_annotated: SpatialData):
+        sdata_blobs_shapes_annotated["blobs_polygons"]["cat"] = ["a", "b", "a", "b", "a"]
+        spec = self._resolve(sdata_blobs_shapes_annotated, "cat")
+        assert spec.colortype == "categorical"
+        assert isinstance(spec.source_vector, pd.Categorical)

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -1047,3 +1047,45 @@ class TestColorSpecTransforms:
     def test_align_to_length_noop_when_already_matching(self):
         spec = self._cont_spec()
         assert spec.align_to_length(4, Color()) is spec
+
+
+class TestColorSpecToRgba:
+    """ColorSpec.to_rgba is the single fill+outline continuous/categorical -> RGBA mapping."""
+
+    @staticmethod
+    def _params() -> CmapParams:
+        from matplotlib import colormaps
+        from matplotlib.colors import Normalize
+
+        # transparent-black na so the na rows are an unambiguous (0, 0, 0, 0)
+        return CmapParams(cmap=colormaps["viridis"], norm=Normalize(0.0, 10.0, clip=False), na_color=Color("#00000000"))
+
+    def test_continuous_maps_finite_via_norm_and_nan_to_na(self):
+        from spatialdata_plot.pl._color import ColorSpec
+
+        p = self._params()
+        rgba = ColorSpec("continuous", None, np.array([0.0, 10.0, np.nan])).to_rgba(p)
+        np.testing.assert_allclose(rgba[0], p.cmap(0.0))
+        np.testing.assert_allclose(rgba[1], p.cmap(1.0))
+        np.testing.assert_allclose(rgba[2], (0.0, 0.0, 0.0, 0.0))
+
+    def test_categorical_hex_to_rgba(self):
+        from spatialdata_plot.pl._color import ColorSpec
+
+        spec = ColorSpec("categorical", pd.Categorical(["a", "b"]), np.array(["#ff0000ff", "#00ff00ff"], dtype=object))
+        np.testing.assert_allclose(spec.to_rgba(self._params()), [[1, 0, 0, 1], [0, 1, 0, 1]])
+
+    def test_object_vector_mixes_numeric_and_colorlike(self):
+        from spatialdata_plot.pl._color import ColorSpec
+
+        p = self._params()
+        rgba = ColorSpec("continuous", None, np.array([0.0, "#ff0000ff", np.nan], dtype=object)).to_rgba(p)
+        np.testing.assert_allclose(rgba[0], p.cmap(0.0))
+        np.testing.assert_allclose(rgba[1], (1.0, 0.0, 0.0, 1.0))
+        np.testing.assert_allclose(rgba[2], (0.0, 0.0, 0.0, 0.0))
+
+    def test_precomputed_rgba_passthrough(self):
+        from spatialdata_plot.pl._color import ColorSpec
+
+        arr = np.array([[1.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 1.0]])
+        np.testing.assert_allclose(ColorSpec("continuous", None, arr).to_rgba(self._params()), arr)

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -888,14 +888,6 @@ class TestResolveContinuousNorm:
         norm = _resolve_continuous_norm(np.array([5.0, 5.0, 5.0]), self._params())
         assert (norm.vmin, norm.vmax) == (0.0, 1.0)
 
-    def test_degenerate_clim_matches_colorbar_mappable(self):
-        # pixel norm and the (datashader) colorbar mappable must agree on a constant column
-        from spatialdata_plot.pl._color import _make_continuous_mappable, _resolve_continuous_norm
-
-        norm = _resolve_continuous_norm(np.array([5.0, 5.0]), self._params())
-        mappable = _make_continuous_mappable(5.0, 5.0, self._params().cmap)
-        assert (norm.vmin, norm.vmax) == (mappable.norm.vmin, mappable.norm.vmax) == (0.0, 1.0)
-
     def test_degenerate_lognorm_is_left_untouched(self):
         # LogNorm domain excludes 0, so the degenerate reset must not fire for it
         from matplotlib.colors import LogNorm

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -963,3 +963,45 @@ class TestResolveColor:
         assert spec.colortype == "categorical"
         assert isinstance(spec.source_vector, pd.Categorical)
         self._assert_predicates(spec, "categorical")
+
+
+class TestColorSpecTransforms:
+    """Immutable ColorSpec transforms reproduce the renderers' lockstep vector mutations (#700)."""
+
+    @staticmethod
+    def _cat_spec():
+        from spatialdata_plot.pl._color import ColorSpec
+
+        src = pd.Categorical(["a", "b", "a", "c"])
+        col = pd.Categorical(["#ff0000", "#00ff00", "#ff0000", "#0000ff"])
+        return ColorSpec("categorical", src, col)
+
+    @staticmethod
+    def _cont_spec():
+        from spatialdata_plot.pl._color import ColorSpec
+
+        return ColorSpec("continuous", None, np.array([1.0, 2.0, 3.0, 4.0]))
+
+    def test_filter_categorical_keeps_dtype_and_drops_unused(self):
+        out = self._cat_spec().filter(np.array([True, False, True, False]))  # keep the two "a"s
+        assert out.colortype == "categorical"
+        assert list(out.source_vector) == ["a", "a"]
+        assert isinstance(out.color_vector.dtype, pd.CategoricalDtype)
+        assert set(out.color_vector.categories) == {"#ff0000"}  # unused colors dropped
+
+    def test_filter_continuous_masks_color_and_keeps_source_none(self):
+        out = self._cont_spec().filter(np.array([True, False, True, False]))
+        assert out.source_vector is None
+        assert list(out.color_vector) == [1.0, 3.0]
+
+    def test_apply_transfunc_is_continuous_only(self):
+        out = self._cont_spec().apply_transfunc(lambda x: x * 10)
+        assert list(out.color_vector) == [10.0, 20.0, 30.0, 40.0]
+        cat = self._cat_spec()
+        assert cat.apply_transfunc(lambda x: x) is cat  # no-op for categorical
+        assert cat.apply_transfunc(None) is cat
+
+    def test_with_color_vector_replaces_only_color(self):
+        out = self._cont_spec().with_color_vector(np.array([9.0]))
+        assert list(out.color_vector) == [9.0]
+        assert out.colortype == "continuous" and out.source_vector is None

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -888,6 +888,14 @@ class TestResolveContinuousNorm:
         norm = _resolve_continuous_norm(np.array([5.0, 5.0, 5.0]), self._params())
         assert (norm.vmin, norm.vmax) == (0.0, 1.0)
 
+    def test_degenerate_clim_matches_colorbar_mappable(self):
+        # pixel norm and the (datashader) colorbar mappable must agree on a constant column
+        from spatialdata_plot.pl._color import _make_continuous_mappable, _resolve_continuous_norm
+
+        norm = _resolve_continuous_norm(np.array([5.0, 5.0]), self._params())
+        mappable = _make_continuous_mappable(5.0, 5.0, self._params().cmap)
+        assert (norm.vmin, norm.vmax) == (mappable.norm.vmin, mappable.norm.vmax) == (0.0, 1.0)
+
     def test_degenerate_lognorm_is_left_untouched(self):
         # LogNorm domain excludes 0, so the degenerate reset must not fire for it
         from matplotlib.colors import LogNorm


### PR DESCRIPTION
**#700 Step 2a**: color state becomes one typed, immutable `ColorSpec` carried through the renderers, replacing the implicit `source_vector is None` + `categorical`-bool encoding.

### What
- `resolve_color() -> ColorSpec` with explicit `colortype ∈ {categorical, continuous, none}` + `is_*` predicates.
- Immutable transforms `filter` / `apply_transfunc` / `align_to_length` / `groups_keep_mask` thread one spec through each renderer — the lockstep two-vector footgun is gone for fill and outline.
- `ColorSpec.to_rgba(cmap_params)`: one continuous/categorical→RGBA mapping for fill **and** outline (was duplicated in `_get_collection_shape` + `_color_vector_to_rgba`).
- The groups filter, warnings/density, and the legend/colorbar seam (`_add_legend_and_colorbar`/`_decorate_outline`) all read the spec's predicates — no more `colortype == "..."` or `source is not None` proxies.
- Deleted: `_filter_groups_transparent_na`, `_maybe_apply_transfunc`, `_align_outline_vector_to_length`, `_apply_mask_to_outline_vectors`, `_color_vector_to_rgba`, the `is_continuous_override` hack. `eq=False` (array fields).

### Fixes (all in the `none` colortype, plus norm)
- `none`-state crashes: `align_to_length` and `_add_outline_legend` called `.categories`/`.remove_unused_categories()` on the na-array; categorical-outline `NaN` pad → `to_rgba_array(nan)`; groups `.isin` on the na-array; datashader-shapes misclassification; a labels rasterize assertion; `_warn_missing_groups`.
- Norm: preserve the subclass (`LogNorm`/`PowerNorm`, was linearized); restore degenerate `vmin==vmax → [0,1]` (LogNorm exempt) in both the pixel norm and the colorbar mappable so they agree.

### Verification
- Behaviour-preserving refactor: local visual-test failure set byte-identical to baseline; non-visual suite green; `to_rgba`/norm correctness locked by unit tests (visual can't verify locally).
- **Intentional pixel changes** (degenerate reset + colorbar, categorical-outline pad, LogNorm-preserve) → affected `test_plot_*` baselines need CI-artifact regen.

No public API change; `ColorSpec`/`resolve_color` are internal.