### PR TITLE
perf(render_points): keep categorical colour as codes+palette (memory at scale)

### DIFF
--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -52,6 +52,7 @@ from spatialdata_plot.pl.utils import (
     _MPL_SINGLE_LETTER_COLORS,
     _build_alignment_dtype_hint,
     _ensure_one_to_one_mapping,
+    _first_color_per_category,
     _format_element_name,
     to_hex,
 )
@@ -907,16 +908,10 @@ def _map_color_seg(
         #  - continuous: outline_color_source_vector is None; outline_color_vector is numeric.
         if outline_color_source_vector is not None:
             cat = pd.Categorical(outline_color_source_vector)
-            cat_codes = cat.codes
-            outline_val_im: ArrayLike = map_array(seg, cell_id, cat_codes + 1)
-            color_arr = np.asarray(outline_color_vector, dtype=object)
-            # Pick the first per-cell hex for each category in one vectorized pass
-            # (avoids `K × O(N)` Python loops on large label sets).
-            cat_colors: list[Any] = [na_color.get_hex_with_alpha()] * len(cat.categories)
-            unique_codes, first_indices = np.unique(cat_codes, return_index=True)
-            for code, idx in zip(unique_codes, first_indices, strict=True):
-                if code >= 0:
-                    cat_colors[code] = color_arr[idx]
+            outline_val_im: ArrayLike = map_array(seg, cell_id, cat.codes + 1)
+            # First per-cell hex for each category (shared one-pass helper); na_color for absent categories.
+            first = _first_color_per_category(cat, outline_color_vector)
+            cat_colors = [first.get(c, na_color.get_hex_with_alpha()) for c in cat.categories]
             outline_cols = colors.to_rgba_array(cat_colors)
         else:
             # Continuous: numeric values normalized via cmap

--- a/src/spatialdata_plot/pl/_datashader.py
+++ b/src/spatialdata_plot/pl/_datashader.py
@@ -97,11 +97,10 @@ def _build_datashader_color_key(
 ) -> dict[str, str]:
     """Build a datashader ``color_key`` dict from a categorical series and its color vector."""
     na_hex = _hex_no_alpha(na_color_hex) if na_color_hex.startswith("#") else na_color_hex
-    colors_arr = np.asarray(color_vector, dtype=object)
     categories = np.asarray(cat_series.categories, dtype=str)
     codes = np.asarray(cat_series.codes)
 
-    if len(colors_arr) != len(codes):
+    if len(color_vector) != len(codes):
         logger.warning(
             f"color_vector length ({len(color_vector)}) does not match categorical series length "
             f"({len(codes)}); some categories may receive the na_color fallback."
@@ -111,11 +110,13 @@ def _build_datashader_color_key(
     # avoiding a Python loop over all points.  See #379.
     unique_codes, first_indices = np.unique(codes, return_index=True)
 
+    # Index color_vector only at those first occurrences (one per category) rather than expanding the
+    # whole per-point vector to an object array — color_vector is a compact pd.Categorical at scale.
     first_color: dict[str, str] = {}
     for code, idx in zip(unique_codes, first_indices, strict=True):
-        if code < 0 or idx >= len(colors_arr):
+        if code < 0 or idx >= len(color_vector):
             continue
-        c = colors_arr[idx]
+        c = color_vector[idx]
         first_color[categories[code]] = _hex_no_alpha(c) if isinstance(c, str) and c.startswith("#") else c
 
     return {cat: first_color.get(cat, na_hex) for cat in categories}
@@ -403,10 +404,17 @@ def _shade_datashader_aggregate(
         and isinstance(color_vector[0], str)
         and color_vector[0].startswith("#")
     ):
-        # Strip alpha on the unique colours and map back rather than parsing once per point; pd.factorize
-        # dedups in O(n) (hash, no sort) where np.unique would sort millions of strings.
-        codes, uniques = pd.factorize(np.asarray(color_vector))
-        color_vector = np.asarray([_hex_no_alpha(c) for c in uniques])[codes]
+        # Strip alpha on the unique colours, never on the per-point vector. color_vector is already a
+        # pd.Categorical (codes + a small palette) at scale: strip its k categories and remap the codes,
+        # staying compact. (Plain-array fallback factorizes in O(n) — hash, no sort.)
+        if isinstance(color_vector, pd.Categorical):
+            stripped = np.asarray([_hex_no_alpha(c) for c in color_vector.categories])
+            uniq_codes, uniques = pd.factorize(stripped)  # dedup over k categories, not n points
+            new_codes = np.where(color_vector.codes >= 0, uniq_codes[color_vector.codes], -1)
+            color_vector = pd.Categorical.from_codes(new_codes, categories=uniques)
+        else:
+            codes, uniques = pd.factorize(np.asarray(color_vector))
+            color_vector = np.asarray([_hex_no_alpha(c) for c in uniques])[codes]
 
     # density without a color column collapses to a sequential count gradient; everything else with no
     # explicit continuous value (categorical or no color) goes through the categorical shader.

--- a/src/spatialdata_plot/pl/_datashader.py
+++ b/src/spatialdata_plot/pl/_datashader.py
@@ -110,8 +110,7 @@ def _build_datashader_color_key(
     # avoiding a Python loop over all points.  See #379.
     unique_codes, first_indices = np.unique(codes, return_index=True)
 
-    # Index color_vector only at those first occurrences (one per category) rather than expanding the
-    # whole per-point vector to an object array — color_vector is a compact pd.Categorical at scale.
+    # Index only the first occurrence per category — color_vector is a compact pd.Categorical at scale.
     first_color: dict[str, str] = {}
     for code, idx in zip(unique_codes, first_indices, strict=True):
         if code < 0 or idx >= len(color_vector):
@@ -404,14 +403,17 @@ def _shade_datashader_aggregate(
         and isinstance(color_vector[0], str)
         and color_vector[0].startswith("#")
     ):
-        # Strip alpha on the unique colours, never on the per-point vector. color_vector is already a
-        # pd.Categorical (codes + a small palette) at scale: strip its k categories and remap the codes,
-        # staying compact. (Plain-array fallback factorizes in O(n) — hash, no sort.)
+        # Strip alpha on the k categories, never on the per-point vector — color_vector is a compact
+        # pd.Categorical at scale. (Plain-array fallback factorizes in O(n): hash, no sort.)
         if isinstance(color_vector, pd.Categorical):
-            stripped = np.asarray([_hex_no_alpha(c) for c in color_vector.categories])
-            uniq_codes, uniques = pd.factorize(stripped)  # dedup over k categories, not n points
-            new_codes = np.where(color_vector.codes >= 0, uniq_codes[color_vector.codes], -1)
-            color_vector = pd.Categorical.from_codes(new_codes, categories=uniques)
+            stripped = [_hex_no_alpha(c) for c in color_vector.categories]
+            uniq_codes, uniques = pd.factorize(np.asarray(stripped))
+            if len(uniques) == len(stripped):
+                color_vector = color_vector.rename_categories(stripped)  # no collisions: reuse the codes as-is
+            else:  # two categories share a stripped colour: remap, keeping the compact int width
+                remapped = uniq_codes[color_vector.codes].astype(color_vector.codes.dtype)
+                remapped[color_vector.codes < 0] = -1
+                color_vector = pd.Categorical.from_codes(remapped, categories=uniques)
         else:
             codes, uniques = pd.factorize(np.asarray(color_vector))
             color_vector = np.asarray([_hex_no_alpha(c) for c in uniques])[codes]

--- a/src/spatialdata_plot/pl/_datashader.py
+++ b/src/spatialdata_plot/pl/_datashader.py
@@ -43,6 +43,7 @@ from spatialdata_plot.pl._color import (
 from spatialdata_plot.pl.render_params import Color, FigParams, ShapesRenderParams, _DsReduction
 from spatialdata_plot.pl.utils import (
     _fast_extent,
+    _first_color_per_category,
     to_hex,
 )
 
@@ -98,26 +99,19 @@ def _build_datashader_color_key(
     """Build a datashader ``color_key`` dict from a categorical series and its color vector."""
     na_hex = _hex_no_alpha(na_color_hex) if na_color_hex.startswith("#") else na_color_hex
     categories = np.asarray(cat_series.categories, dtype=str)
-    codes = np.asarray(cat_series.codes)
 
-    if len(color_vector) != len(codes):
+    if len(color_vector) != len(cat_series.codes):
         logger.warning(
             f"color_vector length ({len(color_vector)}) does not match categorical series length "
-            f"({len(codes)}); some categories may receive the na_color fallback."
+            f"({len(cat_series.codes)}); some categories may receive the na_color fallback."
         )
 
-    # Use np.unique to find the first occurrence of each category in one pass,
-    # avoiding a Python loop over all points.  See #379.
-    unique_codes, first_indices = np.unique(codes, return_index=True)
-
-    # Index only the first occurrence per category — color_vector is a compact pd.Categorical at scale.
-    first_color: dict[str, str] = {}
-    for code, idx in zip(unique_codes, first_indices, strict=True):
-        if code < 0 or idx >= len(color_vector):
-            continue
-        c = color_vector[idx]
-        first_color[categories[code]] = _hex_no_alpha(c) if isinstance(c, str) and c.startswith("#") else c
-
+    # Shared first-colour-per-category pass; strip alpha on the (few) resolved hex colours and fall back
+    # to na_hex for any category not present.
+    first_color = {
+        str(cat): _hex_no_alpha(c) if isinstance(c, str) and c.startswith("#") else c
+        for cat, c in _first_color_per_category(cat_series, color_vector).items()
+    }
     return {cat: first_color.get(cat, na_hex) for cat in categories}
 
 
@@ -343,6 +337,9 @@ def _color_vector_is_uniform(color_vector: Any) -> bool:
     """
     if color_vector is None or len(color_vector) == 0:
         return False
+    if isinstance(color_vector, pd.Categorical):  # compact form: compare int8 codes, never expand
+        codes = color_vector.codes
+        return bool((codes == codes[0]).all())
     arr = np.asarray(color_vector)
     if arr.dtype.kind in "US":  # fixed-width strings (the resolved-hex case): cheap vectorised compare
         return bool((arr == arr[0]).all())

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -19,7 +19,7 @@ import spatialdata as sd
 import xarray as xr
 from matplotlib import patheffects
 from matplotlib.cm import ScalarMappable
-from matplotlib.colors import Colormap, ListedColormap, Normalize
+from matplotlib.colors import BoundaryNorm, Colormap, ListedColormap, Normalize, to_rgba_array
 from scanpy._settings import settings as sc_settings
 from scanpy.plotting._tools.scatterplots import _add_categorical_legend
 from spatialdata import get_extent, get_values
@@ -1056,12 +1056,28 @@ def _scatter_points(
     # scalar ``color=`` instead of a per-point ``c=`` array: matplotlib then skips its per-point colour
     # machinery — the dominant cost at scale (10M points: ~9s -> ~3.7s) — for a visually identical result.
     # Numeric vectors keep the ``c=``/``cmap``/``norm`` path (they need the colormap).
-    cv = np.asarray(color_vector)
     color_kwargs: dict[str, Any]
-    if cv.ndim == 1 and cv.dtype.kind in "US" and _color_vector_is_uniform(cv):
-        color_kwargs = {"color": str(cv[0])}
+    if isinstance(color_vector, pd.Categorical) and (color_vector.codes >= 0).all():
+        # Categorical hex colours: pass the int codes + a ListedColormap of the (few) category colours
+        # instead of expanding to a per-point hex object array (~8x more memory at scale). BoundaryNorm
+        # edges at the half-integers map code i -> colormap entry i exactly, so the RGBA is identical.
+        # (_color.py bakes NaN into the na_color category, so codes >= 0; a stray -1 falls back below.)
+        categories = list(color_vector.categories)
+        if len(categories) == 1:
+            color_kwargs = {"color": str(categories[0])}  # uniform: scalar color=, skip per-point machinery
+        else:
+            n_cat = len(categories)
+            color_kwargs = {
+                "c": color_vector.codes,
+                "cmap": ListedColormap(to_rgba_array(categories)),
+                "norm": BoundaryNorm(np.arange(-0.5, n_cat, 1.0), ncolors=n_cat),
+            }
     else:
-        color_kwargs = {"c": color_vector, "cmap": cmap, "norm": norm}
+        cv = np.asarray(color_vector)
+        if cv.ndim == 1 and cv.dtype.kind in "US" and _color_vector_is_uniform(cv):
+            color_kwargs = {"color": str(cv[0])}
+        else:
+            color_kwargs = {"c": color_vector, "cmap": cmap, "norm": norm}
     return ax.scatter(
         x,
         y,

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -131,20 +131,12 @@ def _want_decorations(color_vector: Any, na_color: Color) -> bool:
     """
     if color_vector is None:
         return False
-    if isinstance(color_vector, pd.Categorical):  # compact fast path: int8 codes, no per-point expand
-        if len(color_vector) == 0:
-            return False
-        if not _color_vector_is_uniform(color_vector):
-            return True
-        first = color_vector[0]
-    else:  # numeric / object / 2-D RGBA arrays (e.g. labels as_points no-color)
-        cv = np.asarray(color_vector)
-        if cv.size == 0:
-            return False
-        if not (cv == cv.flat[0]).all():
-            return True
-        first = cv.flat[0]
-    # all one colour: decorations only if it isn't the na colour
+    cv = np.asarray(color_vector)
+    if cv.size == 0:
+        return False
+    first = cv.flat[0]
+    if not (cv == first).all():
+        return True
     na_hex = na_color.get_hex()
     if isinstance(first, str) and first.startswith("#") and na_hex.startswith("#"):
         return _hex_no_alpha(first) != _hex_no_alpha(na_hex)

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -1057,11 +1057,11 @@ def _scatter_points(
     # machinery — the dominant cost at scale (10M points: ~9s -> ~3.7s) — for a visually identical result.
     # Numeric vectors keep the ``c=``/``cmap``/``norm`` path (they need the colormap).
     color_kwargs: dict[str, Any]
-    if isinstance(color_vector, pd.Categorical) and (color_vector.codes >= 0).all():
+    if isinstance(color_vector, pd.Categorical) and len(color_vector) and (color_vector.codes >= 0).all():
         # Categorical hex colours: pass the int codes + a ListedColormap of the (few) category colours
         # instead of expanding to a per-point hex object array (~8x more memory at scale). BoundaryNorm
         # edges at the half-integers map code i -> colormap entry i exactly, so the RGBA is identical.
-        # (_color.py bakes NaN into the na_color category, so codes >= 0; a stray -1 falls back below.)
+        # _color.py bakes NaN into the na_color category, so codes >= 0 here; anything else takes the path below.
         categories = list(color_vector.categories)
         if len(categories) == 1:
             color_kwargs = {"color": str(categories[0])}  # uniform: scalar color=, skip per-point machinery

--- a/src/spatialdata_plot/pl/render.py
+++ b/src/spatialdata_plot/pl/render.py
@@ -81,6 +81,7 @@ from spatialdata_plot.pl.utils import (
     _categorical_legend_handles,
     _decorate_axs,
     _fast_extent,
+    _first_color_per_category,
     _join_table_for_element,
     _legend_ncol,
     _mpl_ax_contains_elements,
@@ -130,12 +131,20 @@ def _want_decorations(color_vector: Any, na_color: Color) -> bool:
     """
     if color_vector is None:
         return False
-    cv = np.asarray(color_vector)
-    if cv.size == 0:
-        return False
-    first = cv.flat[0]
-    if not (cv == first).all():
-        return True
+    if isinstance(color_vector, pd.Categorical):  # compact fast path: int8 codes, no per-point expand
+        if len(color_vector) == 0:
+            return False
+        if not _color_vector_is_uniform(color_vector):
+            return True
+        first = color_vector[0]
+    else:  # numeric / object / 2-D RGBA arrays (e.g. labels as_points no-color)
+        cv = np.asarray(color_vector)
+        if cv.size == 0:
+            return False
+        if not (cv == cv.flat[0]).all():
+            return True
+        first = cv.flat[0]
+    # all one colour: decorations only if it isn't the na colour
     na_hex = na_color.get_hex()
     if isinstance(first, str) and first.startswith("#") and na_hex.startswith("#"):
         return _hex_no_alpha(first) != _hex_no_alpha(na_hex)
@@ -500,10 +509,7 @@ def _add_outline_legend(
     """
     cats = outline_color_source_vector.remove_unused_categories().unique()
     cats = cats[~cats.isnull()]
-    mapping_df = pd.DataFrame(
-        {"cats": outline_color_source_vector.remove_unused_categories(), "color": outline_color_vector}
-    )
-    color_map = mapping_df.drop_duplicates("cats").set_index("cats")["color"].to_dict()
+    color_map = _first_color_per_category(outline_color_source_vector.remove_unused_categories(), outline_color_vector)
 
     outline_handles = _categorical_legend_handles(ax, {c: color_map[c] for c in cats})
 

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -454,6 +454,26 @@ def _stack_categorical_legend(
 _MAX_LEGEND_CATEGORIES = len(palettes.default_102)
 
 
+def _first_color_per_category(source: pd.Categorical, color_vector: Any) -> dict[Any, Any]:
+    """Map each *used* category to the colour at its first occurrence, in appearance order.
+
+    One vectorised pass over the codes (no per-point Python loop, see #379), shared by the legend and
+    datashader colour-key builders so the "first colour per category" logic lives once. ``source`` is the
+    length-N categorical; ``color_vector`` is the aligned colour vector. Categories never present are
+    omitted (callers add any na fallback); appearance order matches the old ``drop_duplicates`` first row.
+    """
+    cats = source.categories
+    codes = np.asarray(source.codes)
+    at = color_vector.iloc if isinstance(color_vector, pd.Series) else color_vector  # positional access
+    unique_codes, first_indices = np.unique(codes, return_index=True)
+    out: dict[Any, Any] = {}
+    for i in np.argsort(first_indices):  # appearance order
+        code, idx = unique_codes[i], first_indices[i]
+        if code >= 0 and idx < len(color_vector):
+            out[cats[code]] = at[idx]
+    return out
+
+
 def _decorate_axs(
     ax: Axes,
     cax: PatchCollection,
@@ -490,13 +510,7 @@ def _decorate_axs(
             clusters = color_source_vector.remove_unused_categories().unique()
             clusters = clusters[~clusters.isnull()]
             # derive mapping from color_source_vector and color_vector
-            group_to_color_matching = pd.DataFrame(
-                {
-                    "cats": color_source_vector.remove_unused_categories(),
-                    "color": color_vector,
-                }
-            )
-            color_mapping = group_to_color_matching.drop_duplicates("cats").set_index("cats")["color"].to_dict()
+            color_mapping = _first_color_per_category(color_source_vector.remove_unused_categories(), color_vector)
             color_mapping = {k: v for k, v in color_mapping.items() if not pd.isnull(k)}  # NA handled separately
             # A 2nd categorical render would make scanpy's bare `ax.legend()` merge every labeled
             # artist into one legend and drop the first (#364), so route 2nd+ legends (i.e. when a

--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -463,15 +463,13 @@ def _first_color_per_category(source: pd.Categorical, color_vector: Any) -> dict
     omitted (callers add any na fallback); appearance order matches the old ``drop_duplicates`` first row.
     """
     cats = source.categories
-    codes = np.asarray(source.codes)
-    at = color_vector.iloc if isinstance(color_vector, pd.Series) else color_vector  # positional access
-    unique_codes, first_indices = np.unique(codes, return_index=True)
-    out: dict[Any, Any] = {}
-    for i in np.argsort(first_indices):  # appearance order
-        code, idx = unique_codes[i], first_indices[i]
-        if code >= 0 and idx < len(color_vector):
-            out[cats[code]] = at[idx]
-    return out
+    at = color_vector.iloc if isinstance(color_vector, pd.Series) else color_vector  # positional
+    unique_codes, first_indices = np.unique(np.asarray(source.codes), return_index=True)
+    return {
+        cats[code]: at[idx]
+        for idx, code in sorted(zip(first_indices, unique_codes, strict=True))  # appearance order
+        if code >= 0 and idx < len(color_vector)
+    }
 
 
 def _decorate_axs(

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -1349,22 +1349,17 @@ def _categorical_hex_vector(n: int, k: int, seed: int = 0) -> pd.Categorical:
     return pd.Categorical(pd.Series(src).map(palette))
 
 
+_SCATTER_KW = {"size": 10.0, "cmap": "viridis", "norm": Normalize(), "alpha": 1.0, "trans_data": None, "zorder": 1}
+
+
 def test_scatter_points_categorical_codes_match_per_point_hex():
     # The codes+ListedColormap path must produce byte-identical RGBA to passing the per-point hex array.
     cv = _categorical_hex_vector(400, k=6, seed=1)
     rng = np.random.default_rng(2)
     x, y = rng.random(400), rng.random(400)
-    common = {
-        "size": 10.0,
-        "cmap": plt.get_cmap("viridis"),
-        "norm": Normalize(),
-        "alpha": 1.0,
-        "trans_data": None,
-        "zorder": 1,
-    }
 
     fig, ax = plt.subplots()
-    sc_codes = _scatter_points(ax, x, y, cv, **common)  # exercises the new codes path
+    sc_codes = _scatter_points(ax, x, y, cv, **_SCATTER_KW)  # exercises the new codes path
     sc_codes.update_scalarmappable()
     fc_codes = sc_codes.get_facecolors()
     plt.close(fig)
@@ -1382,18 +1377,7 @@ def test_scatter_points_single_category_uses_scalar_color():
     cv = _categorical_hex_vector(300, k=1, seed=3)
     rng = np.random.default_rng(5)
     fig, ax = plt.subplots()
-    sc = _scatter_points(
-        ax,
-        rng.random(300),
-        rng.random(300),
-        cv,
-        size=10.0,
-        cmap=plt.get_cmap("viridis"),
-        norm=Normalize(),
-        alpha=1.0,
-        trans_data=None,
-        zorder=1,
-    )
+    sc = _scatter_points(ax, rng.random(300), rng.random(300), cv, **_SCATTER_KW)
     assert sc.get_facecolors().shape[0] == 1  # scalar color -> single facecolor
     plt.close(fig)
 

--- a/tests/pl/test_render_points.py
+++ b/tests/pl/test_render_points.py
@@ -31,7 +31,7 @@ from spatialdata_plot.pl._datashader import (
     _ds_shade_categorical,
     _pad_degenerate_extent,
 )
-from spatialdata_plot.pl.render import _marker_spread_px, _warn_groups_ignored_continuous
+from spatialdata_plot.pl.render import _marker_spread_px, _scatter_points, _warn_groups_ignored_continuous
 from tests.conftest import (
     CANVAS_HEIGHT,
     CANVAS_WIDTH,
@@ -1338,3 +1338,76 @@ def test_datashader_zero_extent_renders(coords):
     sdata = SpatialData(points={"points": PointsModel.parse(df)})
     sdata.pl.render_points("points", method="datashader").pl.show()
     plt.close("all")
+
+
+def _categorical_hex_vector(n: int, k: int, seed: int = 0) -> pd.Categorical:
+    """Per-point hex colour vector as _set_color_source_vec builds it: Categorical(source.map(palette))."""
+    rng = np.random.default_rng(seed)
+    cats = [f"ct{i}" for i in range(k)]
+    src = pd.Categorical(rng.choice(cats, n), categories=cats)
+    palette = {c: f"#{(i * 9973) % 0xFFFFFF:06x}ff" for i, c in enumerate(cats)}
+    return pd.Categorical(pd.Series(src).map(palette))
+
+
+def test_scatter_points_categorical_codes_match_per_point_hex():
+    # The codes+ListedColormap path must produce byte-identical RGBA to passing the per-point hex array.
+    cv = _categorical_hex_vector(400, k=6, seed=1)
+    rng = np.random.default_rng(2)
+    x, y = rng.random(400), rng.random(400)
+    common = {
+        "size": 10.0,
+        "cmap": plt.get_cmap("viridis"),
+        "norm": Normalize(),
+        "alpha": 1.0,
+        "trans_data": None,
+        "zorder": 1,
+    }
+
+    fig, ax = plt.subplots()
+    sc_codes = _scatter_points(ax, x, y, cv, **common)  # exercises the new codes path
+    sc_codes.update_scalarmappable()
+    fc_codes = sc_codes.get_facecolors()
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    sc_hex = ax.scatter(x, y, c=np.asarray(cv), s=10.0)  # reference: literal per-point hex
+    fc_hex = sc_hex.get_facecolors()
+    plt.close(fig)
+
+    assert np.abs(fc_codes - fc_hex).max() == 0.0
+
+
+def test_scatter_points_single_category_uses_scalar_color():
+    # A single resolved colour must keep the scalar color= fast path (one facecolor, not a per-point array).
+    cv = _categorical_hex_vector(300, k=1, seed=3)
+    rng = np.random.default_rng(5)
+    fig, ax = plt.subplots()
+    sc = _scatter_points(
+        ax,
+        rng.random(300),
+        rng.random(300),
+        cv,
+        size=10.0,
+        cmap=plt.get_cmap("viridis"),
+        norm=Normalize(),
+        alpha=1.0,
+        trans_data=None,
+        zorder=1,
+    )
+    assert sc.get_facecolors().shape[0] == 1  # scalar color -> single facecolor
+    plt.close(fig)
+
+
+def test_build_datashader_color_key_categorical_indexes_palette():
+    # The color key must map each category to its alpha-stripped colour without expanding the full vector.
+    cv = _categorical_hex_vector(500, k=5, seed=4)
+    source = pd.Categorical([f"g{i % 5}" for i in range(500)], categories=[f"g{i}" for i in range(5)])
+    key = _build_datashader_color_key(source, cv, "#808080ff")
+    # equivalence with the previous object-array expansion:
+    colors_arr = np.asarray(cv, dtype=object)
+    codes = source.codes
+    expected = {}
+    for code, idx in zip(*np.unique(codes, return_index=True), strict=True):
+        c = colors_arr[idx]
+        expected[str(np.asarray(source.categories)[code])] = c[:7] if c.startswith("#") else c
+    assert key == expected

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -13,12 +13,12 @@ from spatialdata.models import Labels2DModel, PointsModel, ShapesModel, TableMod
 
 import spatialdata_plot
 from spatialdata_plot.pl import measure_obs
+from spatialdata_plot.pl._color import _set_outline
 from spatialdata_plot.pl._datashader import (
     _apply_cmap_alpha_to_datashader_result,
     _datashader_map_aggregate_to_color,
 )
 from spatialdata_plot.pl.render_params import CmapParams, Color, ColorLike, colormap_with_alpha
-from spatialdata_plot.pl._color import _set_outline
 from spatialdata_plot.pl.utils import set_zero_in_cmap_to_transparent
 from tests.conftest import DPI, PlotTester, PlotTesterMeta
 
@@ -1240,3 +1240,12 @@ def test_first_color_per_category_positional_for_series():
     source = pd.Categorical(["a", "b", "a"], categories=["a", "b"])
     cv = pd.Series(["#111111", "#222222", "#111111"], index=[10, 20, 30])
     assert _first_color_per_category(source, cv) == {"a": "#111111", "b": "#222222"}
+
+
+def test_first_color_per_category_skips_nan_and_handles_numeric_categories():
+    from spatialdata_plot.pl.utils import _first_color_per_category
+
+    # NaN rows (code -1) contribute no entry; numeric categories key the dict by their value.
+    source = pd.Categorical([1, None, 2, 1], categories=[1, 2])
+    cv = ["#aaaaaa", "#ffffff", "#bbbbbb", "#aaaaaa"]
+    assert _first_color_per_category(source, cv) == {1: "#aaaaaa", 2: "#bbbbbb"}

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -1212,3 +1212,31 @@ class TestPercentileNormalize:
         resolved = _resolve_continuous_norm(values, _prepare_cmap_norm(norm=PercentileNormalize(0, 99)))
         assert resolved.vmax == pytest.approx(np.percentile(values, 99))
         assert resolved.vmax < 10000.0
+
+
+def test_first_color_per_category_matches_drop_duplicates():
+    # Shared helper must reproduce the old drop_duplicates mapping: used categories only, in
+    # first-appearance order (the order the stacked-legend path iterates).
+    from spatialdata_plot.pl.utils import _first_color_per_category
+
+    # rows appear B, A, C (D never used); category order is A, B, C, D
+    source = pd.Categorical(["B", "A", "C", "B", "A"], categories=["A", "B", "C", "D"])
+    color_vector = pd.Categorical(["#00ff00", "#ff0000", "#0000ff", "#00ff00", "#ff0000"])
+
+    mapping_df = pd.DataFrame({"cats": source, "color": color_vector})
+    expected = mapping_df.drop_duplicates("cats").set_index("cats")["color"].to_dict()
+    expected = {k: v for k, v in expected.items() if not pd.isnull(k)}
+
+    got = _first_color_per_category(source, color_vector)
+    assert got == expected
+    assert list(got.items()) == list(expected.items())  # appearance order, not category order
+
+
+def test_first_color_per_category_positional_for_series():
+    # A pd.Series color_vector with a non-default index must be indexed positionally (matches the old
+    # np.asarray(...)[idx]), not by label.
+    from spatialdata_plot.pl.utils import _first_color_per_category
+
+    source = pd.Categorical(["a", "b", "a"], categories=["a", "b"])
+    cv = pd.Series(["#111111", "#222222", "#111111"], index=[10, 20, 30])
+    assert _first_color_per_category(source, cv) == {"a": "#111111", "b": "#222222"}


### PR DESCRIPTION
Categorical point colour is already a compact `pd.Categorical` (codes + small hex palette), but every consumer re-expanded it to a per-point hex object array. This keeps it compact — the next memory wall after #730.

**Changes**
- `_build_datashader_color_key`: read one colour per category instead of `np.asarray`-ing the whole vector.
- datashader alpha strip: strip the `k` categories and reuse the codes, not expand → re-factorize → re-expand.
- `_scatter_points`: non-uniform categorical → `c=codes` + `ListedColormap` + `BoundaryNorm` (single category keeps the scalar `color=` fast path).

**No behaviour change**: a `main`-vs-branch render of {categorical, continuous, uniform} × {matplotlib, datashader} is byte-identical (max RGBA diff 0), so visual baselines don't move.

**Perf** (20M points, 20 cats): datashader strip 720 MB / 962 ms → 340 MB / 117 ms (2.1× mem, 8× faster); matplotlib `c=` payload ~8× smaller.


---

**Scope expanded (closes #732):** also unify the shared legend/decoration path. The k-sized category→colour mapping was rebuilt in 4 places (2 `drop_duplicates` frames + 2 `np.unique` loops) from the expanded per-element vector; replaced by one `utils._first_color_per_category` helper (used by `_decorate_axs`, the outline legend, the datashader colour-key, and `_map_color_seg`). `_want_decorations` and `_color_vector_is_uniform` gain an int8-codes fast path for `pd.Categorical` (no per-element expansion). Byte-identical: per-site equivalence (incl. legend order) + `main`-vs-branch RGBA == 0 across points/shapes legends, groups subset, mpl + datashader.
