### PR TITLE
perf(color): map categorical shapes colour by code, not per-row hex parse

### DIFF
--- a/src/spatialdata_plot/pl/_color.py
+++ b/src/spatialdata_plot/pl/_color.py
@@ -777,7 +777,16 @@ class ColorSpec:
         via norm+cmap with NaN/non-finite rows painted ``na_color``; an object vector mixes the two.
         """
         if self.source_vector is not None:  # categorical or none: color_vector holds per-row hex
-            return np.asarray(colors.to_rgba_array(list(self.color_vector)))
+            cv = self.color_vector
+            if isinstance(getattr(cv, "dtype", None), pd.CategoricalDtype):
+                # categories are hex (resolution fills NaN with an na_color category -> codes >= 0),
+                # so parse the few categories once and gather by code instead of parsing every row
+                lut = np.asarray(colors.to_rgba_array(cv.categories.to_numpy()))
+                return lut[cv.codes]
+            # object vector (align_to_length pad / uniform na): factorize the distinct colours and
+            # gather back (factorize keeps any NaN as a real code, so the gather stays in-bounds)
+            codes, uniq = pd.factorize(np.asarray(cv, dtype=object), sort=False, use_na_sentinel=False)
+            return np.asarray(colors.to_rgba_array(list(uniq)))[codes]
         arr = np.asarray(self.color_vector)
         if arr.ndim == 2 and arr.shape[1] in (3, 4) and np.issubdtype(arr.dtype, np.number):
             return np.asarray(colors.to_rgba_array(arr))

--- a/tests/pl/test_utils.py
+++ b/tests/pl/test_utils.py
@@ -1127,6 +1127,28 @@ class TestColorSpecToRgba:
         arr = np.array([[1.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 1.0]])
         np.testing.assert_allclose(ColorSpec("continuous", None, arr).to_rgba(self._params()), arr)
 
+    def test_codes_gather_matches_per_row_parse(self):
+        # the categorical codes-gather and the object factorize-gather must equal to_rgba_array(list(...))
+        from matplotlib import colors
+
+        from spatialdata_plot.pl._color import ColorSpec
+
+        hexes = ["#e41a1cff", "#377eb8ff", "#4daf4aff", "#984ea3ff"]
+        na = "#cccccc00"
+        rng = np.random.default_rng(0)
+        clean = pd.Categorical.from_codes(rng.integers(0, len(hexes), 2000), categories=hexes)
+        with_na = pd.Categorical.from_codes(rng.integers(0, len(hexes) + 1, 2000), categories=[*hexes, na])
+        variants = [
+            clean,  # categorical fast-path
+            with_na,  # NaN replaced with an na_color category -> codes still >= 0
+            clean[:800].remove_unused_categories(),  # filtered -> remapped codes
+            np.full(500, na, dtype=object),  # uniform na (object vector)
+            np.concatenate([np.asarray(list(clean[:300]), dtype=object), np.full(100, na, dtype=object)]),  # padded
+        ]
+        for cv in variants:  # cv doubles as the (only-checked-for-not-None) source_vector
+            spec = ColorSpec("categorical" if hasattr(cv, "codes") else "none", cv, cv)
+            np.testing.assert_array_equal(spec.to_rgba(self._params()), np.asarray(colors.to_rgba_array(list(cv))))
+
 
 class TestPercentileNormalize:
     """PercentileNormalize + _resolve_continuous_norm (issue #370: dim multichannel renders)."""


### PR DESCRIPTION
## Problem
`ColorSpec.to_rgba` — the matplotlib shapes **fill + outline** colour mapping — parses every row via `to_rgba_array(list(color_vector))`. For a categorical `color_vector` (K distinct hex strings over N rows) that is O(N) string parsing for O(K) actual colours.

## Fix
- **Categorical** `color_vector`: parse the K categories once, gather by `.codes` (codes ≥ 0 — resolution fills NaN with an explicit `na_color` category, `_color.py:682–685`).
- **Object** `color_vector` (`align_to_length` pad / uniform na): `pd.factorize(sort=False)` on the distinct colours, then gather. (`np.unique` would *sort* the hex strings and is slower than the baseline at scale — deliberately avoided.)

## Byte-identical
Verified main-vs-branch on real renders — categorical fill, categorical+outline, categorical+groups, none — **max|diff| = 0**. Unit test `TestColorSpecToRgba` locks `to_rgba` against the per-row `to_rgba_array(list(...))` across all 5 `color_vector` variants (clean / na-category / filtered / none-uniform / object-after-align).

## Scope & impact
- Matplotlib **shapes** path only. Continuous (`source_vector is None`) untouched; labels (`map_array` codes) and points (#731) already use the compact form; datashader shapes don't call `to_rgba`.
- Function micro-benchmark: **~56×** categorical, **~16×** object, ~2.5× less peak on the colour array. End-to-end it is a small fraction of a shapes render (geometry build dominates post-#735) — this lands as a clean, low-risk, byte-identical reduction, not a headline end-to-end speedup.