### PR TITLE
fix: `pl.show()` now displays in a plain Python REPL

### DIFF
--- a/src/spatialdata_plot/pl/basic.py
+++ b/src/spatialdata_plot/pl/basic.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import sys
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
@@ -1606,15 +1605,13 @@ class PlotAccessor:
         if fig_params.fig is not None and save is not None:
             save_fig(fig_params.fig, path=save)
 
-        # Show the plot unless the caller opted out.
-        # Default (show=None): display in non-interactive mode (scripts), suppress in interactive
-        # sessions. We check both sys.ps1 (standard REPL) and matplotlib.is_interactive()
-        # (covers IPython, Jupyter, plt.ion(), and IDE consoles like PyCharm).
-        # When the user supplies their own axes, they manage the figure lifecycle, so we
-        # default to not calling plt.show(). This allows multiple .pl.show(ax=...) calls
-        # to accumulate content on the same axes (see #362, #71).
+        # Default (show=None): show only when matplotlib is non-interactive. Interactive backends
+        # (Jupyter, IPython, plt.ion()) auto-render, so plt.show() is redundant; scripts and a plain
+        # REPL don't -- and a REPL sets sys.ps1 while staying non-interactive, so we can't key off
+        # sys.ps1. With a user-supplied ax the caller owns the figure, so default to no show (lets
+        # repeated .pl.show(ax=...) accumulate on one axes).
         if show is None:
-            show = False if user_supplied_ax else (not hasattr(sys, "ps1") and not matplotlib.is_interactive())
+            show = False if user_supplied_ax else not matplotlib.is_interactive()
         if show:
             plt.show()
         return (fig_params.ax if fig_params.axs is None else fig_params.axs) if return_ax else None  # shuts up ruff

--- a/tests/pl/test_show.py
+++ b/tests/pl/test_show.py
@@ -101,6 +101,24 @@ class TestShow(PlotTester, metaclass=PlotTesterMeta):
             mock_show.assert_called_once()
         plt.close("all")
 
+    @pytest.mark.parametrize("interactive,expected_calls", [(False, 1), (True, 0)])
+    def test_show_default_keys_off_is_interactive(
+        self, sdata_blobs: SpatialData, monkeypatch, interactive: bool, expected_calls: int
+    ):
+        """show=None calls plt.show() iff matplotlib is non-interactive, ignoring sys.ps1.
+
+        sys.ps1 is set in both cases to simulate a REPL; only matplotlib.is_interactive() may
+        decide, so a plain (non-interactive) REPL still displays the figure (regression for #68).
+        """
+        monkeypatch.setattr("sys.ps1", ">>> ", raising=False)
+        with (
+            patch("spatialdata_plot.pl.basic.matplotlib.is_interactive", return_value=interactive),
+            patch("spatialdata_plot.pl.basic.plt.show") as mock_show,
+        ):
+            sdata_blobs.pl.render_images(element="blobs_image").pl.show()
+            assert mock_show.call_count == expected_calls
+        plt.close("all")
+
     def test_frameon_false_hides_axes_decorations(self, sdata_blobs: SpatialData):
         """frameon=False should turn off axes decorations (regression for #204)."""
         ax = sdata_blobs.pl.render_images(element="blobs_image").pl.show(frameon=False, return_ax=True, show=False)


### PR DESCRIPTION
## Problem

Fixes #68. `pl.show()` did not display the figure in a plain Python REPL (PyCharm console, pasted REPL, `python -i`); users had to call `plt.show()` manually. Most recently re-reported [here](https://github.com/scverse/spatialdata-plot/issues/68#issuecomment-4787594596).

## Root cause

The `show=None` default keyed off `not hasattr(sys, "ps1")`. A plain Python REPL sets `sys.ps1` but leaves matplotlib **non-interactive** (unlike Jupyter/IPython), so `plt.show()` was suppressed and nothing rendered.

## Fix

Drop the `sys.ps1` check and decide purely on `matplotlib.is_interactive()`:

- interactive backends (Jupyter, IPython, `plt.ion()`) auto-render → no `plt.show()`;
- scripts and plain REPLs are non-interactive → explicit `plt.show()`.

The new condition is strictly more permissive than the old one, so it never suppresses a `show()` the old code emitted — it only adds the missing REPL case. Removed the now-unused `import sys`.

## Tests

Added `test_show_default_keys_off_is_interactive` (parametrized over the interactive flag, `sys.ps1` set in both cases to prove the decision ignores it). Verified to fail on the old logic and pass on the fix.