### PR TITLE
fix(scalebar): accept int for scalebar_dx

### DIFF
--- a/src/spatialdata_plot/pl/utils.py
+++ b/src/spatialdata_plot/pl/utils.py
@@ -377,7 +377,7 @@ def _get_scalebar(
     len_lib: int | None = None,
 ) -> tuple[Sequence[float] | None, Sequence[str] | None]:
     if scalebar_dx is not None:
-        _scalebar_dx = _get_list(scalebar_dx, _type=float, ref_len=len_lib, name="scalebar_dx")
+        _scalebar_dx = _get_list(scalebar_dx, _type=(int, float), ref_len=len_lib, name="scalebar_dx")
         scalebar_units = "um" if scalebar_units is None else scalebar_units
         _scalebar_units = _get_list(scalebar_units, _type=str, ref_len=len_lib, name="scalebar_units")
     else:


### PR DESCRIPTION
## Problem

`scalebar_dx` rejected plain `int` values even though validation allowed them.

`_validate` accepts `int | float` for `scalebar_dx`, but `_get_scalebar` narrowed to `float` only via `_get_list(..., _type=float)`. So `pl.show(scalebar_dx=100)` passed validation and then raised:

```
ValueError: Can't make a list from variable: `100`
```