### PR TITLE
docs: fix stale gallery link and broken DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Codecov][badge-codecov]][link-codecov]
 [![Documentation][badge-pypi]][link-pypi]
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/spatialdata-plot/badges/version.svg)](https://anaconda.org/conda-forge/spatialdata-plot)
-[![DOI](https://zenodo.org/badge/588223127.svg)](https://zenodo.org/badge/latestdoi/588223127)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21876186.svg)](https://doi.org/10.5281/zenodo.21876186)
 
 [badge-tests]: https://img.shields.io/github/actions/workflow/status/scverse/spatialdata-plot/test.yaml?branch=main
 [link-tests]: https://github.com/scverse/spatialdata-plot/actions/workflows/test.yml

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -4,7 +4,7 @@ Runnable examples demonstrating `spatialdata-plot` on real spatial-omics
 datasets and on the lightweight `blobs` dataset.
 
 Sources live in
-[`scverse/spatialdata-plot-notebooks`](https://github.com/scverse/spatialdata-plot-notebooks);
+[`scverse/spatialdata-plot-tutorials`](https://github.com/scverse/spatialdata-plot-tutorials);
 every notebook is executable end-to-end and re-executed on a weekly schedule
 against the latest `spatialdata-plot` release.
 


### PR DESCRIPTION
Two small docs fixes.

### 1. Stale gallery source link
The notebooks submodule was renamed `scverse/spatialdata-plot-notebooks` -> `scverse/spatialdata-plot-tutorials` (already reflected in `.gitmodules`), but `docs/gallery.md` still linked the old repo in its *Sources* line. GitHub redirects the old URL, so the link worked but was stale.

### 2. Broken DOI badge
The README DOI badge used the redirect-style form (`zenodo.org/badge/<repoid>.svg`), which returns a `302`. GitHub's camo image proxy caches that redirect instead of following it to the SVG, so the badge renders as a broken image. Switched to the direct DOI badge form used by `scverse/spatialdata` (`zenodo.org/badge/DOI/10.5281/zenodo.<id>.svg` -> `200 image/svg+xml`, no redirect).