### PR TITLE
Fix contributor dependency installation instructions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -134,7 +134,7 @@ we describe how you can manage environments manually using `pip`:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev,test,doc]"
+pip install -e . --group dev --group test --group doc
 ```
 
 The `.venv` directory is typically automatically discovered by IDEs such as VS Code.


### PR DESCRIPTION
Mirroring scverse/spatialdata#1174 this PR  replaces the obsolete editable-install extras syntax in the pip contribution instructions with pip dependency groups.

Development dependencies are declared under `[dependency-groups]`, not `[project.optional-dependencies]`. As a result, following the current instructions, `pip install -e ".[dev,test,doc]"` warns that those extras do not exist and does not install the contributor dependencies.
The updated instructions uses groups: `pip install -e . --group dev --group test --group doc` - which will actually install the declared dependencies.




